### PR TITLE
Add Vodka R support card events

### DIFF
--- a/translations/story/80/1008/001 (憧れのセリフ).json
+++ b/translations/story/80/1008/001 (憧れのセリフ).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある日、トレーナー室へ向かっていると――",
-            "enText": "One day, on the way\nto the trainer's office...",
+            "enText": "One day, on the way to the\ntrainer's office...",
             "nextBlock": 2,
             "pathId": 6568414105838612420,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！！』",
-            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\"\n\"Come, I'll kick your ass.\"",
+            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\" \"Come,\nI'll kick your ass.\"",
             "nextBlock": 3,
             "pathId": -2751798553862275875,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なんっかちげーな。もーちっとこう……\r\n……『ブチカマすぜぇぇ！！』",
-            "enText": "Hmm, that feels off. It should be\nmore like... \"I'm gonna kick your ass!\"",
+            "enText": "Hmm, that feels off. It should be more\nlike... \"I'm gonna kick your ass!\"",
             "nextBlock": 4,
             "choices": [
                 {
@@ -43,7 +43,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "――ハッ！\r\nアアアアンタ、いつの間に……！",
-            "enText": "--Woah!\nS-since when have you been here?",
+            "enText": "--Woah! S-since when have you been here?",
             "nextBlock": 5,
             "pathId": 5605984693871499806,
             "blockIdx": 4
@@ -52,7 +52,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "つーか、まてまて誰にも言うなよ！？\r\nカッコつけの練習見られるとかダセェだろ！？",
-            "enText": "I mean, don't tell anyone about this!\nBeing seen practicing cool phrases\nwould be seriously lame.",
+            "enText": "I mean, don't tell anyone about this! Being\nseen practicing cool phrases would be\nseriously lame.",
             "nextBlock": 6,
             "pathId": -4716578934516563664,
             "blockIdx": 5
@@ -61,7 +61,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "それに、本当はもっとカッケェんだ。\r\n今のは全然仕上がってねーの！",
-            "enText": "The real deal's much cooler too.\nI haven't managed to get it down\nat all yet.",
+            "enText": "The real deal's much cooler too. I haven't\nmanaged to get it down at all yet.",
             "nextBlock": 7,
             "choices": [
                 {
@@ -82,7 +82,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ああ、俺の好きな不良漫画のワンシーンでさ、\r\n下剋上を誓って、トップに宣戦布告すんだよ。",
-            "enText": "It's a phrase from a\ndelinquent manga that I like.\nIn that scene, the main character\ndeclares that he'll overthrow the top.",
+            "enText": "It's a phrase from a delinquent manga that I\nlike. In that scene, the main character\ndeclares that he'll overthrow the top.",
             "nextBlock": 8,
             "pathId": -5823152948019756289,
             "blockIdx": 7
@@ -91,7 +91,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！』\r\nってなぁ！　くぅ～～～、カッケェ～～ッ！",
-            "enText": "So he's like \"I'm gonna kick your ass!\"\nMan, he's seriously so cool!",
+            "enText": "So he's like \"I'm gonna kick your ass!\" Man,\nhe's seriously so cool!",
             "nextBlock": 9,
             "pathId": -4401138221719148632,
             "blockIdx": 8
@@ -121,7 +121,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "見た目を……！　その手があったか！\r\n確かに、あの漫画のヤツら超ムキムキだぜ！",
-            "enText": "Oh, I didn't consider looking wild yet.\nThinking of it, everyone in the\nmanga is really muscular too!",
+            "enText": "Oh, I didn't consider looking wild yet.\nThinking of it, everyone in the manga is\nreally muscular too!",
             "nextBlock": 11,
             "pathId": -1067756012550727100,
             "blockIdx": 10
@@ -130,7 +130,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ムキムキになりゃ、ムキムキの見てる世界が\r\nわかるかもしんねぇ！",
-            "enText": "If I become really muscular too,\nmaybe I'll understand the way\nbuff people see the world better!",
+            "enText": "If I become really muscular too,\nmaybe I'll understand the way buff\npeople see the world better!",
             "nextBlock": 12,
             "pathId": -7760042973725619736,
             "blockIdx": 11
@@ -148,7 +148,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "その後、ウオッカがジムにて、かなり熱心に\r\n筋トレをしていたという噂を聞いた。",
-            "enText": "After that, I heard about how\nVodka feverously trained at the gym.",
+            "enText": "After that, I heard about how Vodka\nfeverously trained at the gym.",
             "nextBlock": -1,
             "pathId": 4728923334065708207,
             "blockIdx": 13
@@ -157,7 +157,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ワイルドなポーズか……。\r\n確かに、カッケェポーズでキめてたな……。",
-            "enText": "Striking a cool pose, huh...\nYeah, I think that could work.",
+            "enText": "Striking a cool pose, huh... Yeah,\nI think that could work.",
             "nextBlock": 15,
             "pathId": -5901416184483430351,
             "blockIdx": 14
@@ -166,7 +166,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "こうか？　それともこう？　こっちがいいか？\r\n意外とポーズとるの、筋肉使うな！？",
-            "enText": "Like this? Or more like this?\nWhat do you think about this?\nWoah, striking a pose uses more\nmuscles than I expected!",
+            "enText": "Like this? Or more like this? What do you\nthink about this? Woah, striking a pose uses\nmore muscles than I expected!",
             "nextBlock": 16,
             "pathId": 6551231938462432627,
             "blockIdx": 15
@@ -175,7 +175,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スッゲーテンション上がってきたぜ……！\r\nちょっと鏡取ってくる！　サンキューな！",
-            "enText": "Alright, now I'm pumped! Time to go\ncheck this out in a mirror! Thanks!",
+            "enText": "Alright, now I'm pumped! Time to go check\nthis out in a mirror! Thanks!",
             "nextBlock": 17,
             "pathId": -8243106386738906873,
             "blockIdx": 16
@@ -184,7 +184,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ウオッカのポーズの研究は、\r\n夜が更けるまで熱心に行われたようだった。",
-            "enText": "And so, Vodka enthusiastically\npracticed posing late into the night.",
+            "enText": "And so, Vodka enthusiastically practiced\nposing late into the night.",
             "nextBlock": -1,
             "pathId": 3346411762792462372,
             "blockIdx": 17

--- a/translations/story/80/1008/001 (憧れのセリフ).json
+++ b/translations/story/80/1008/001 (憧れのセリフ).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある日、トレーナー室へ向かっていると――",
-            "enText": "One day, I was on my way to \nthe trainer's office.",
+            "enText": "One day, on the way\nto the trainer's office...",
             "nextBlock": 2,
             "pathId": 6568414105838612420,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！！』",
-            "enText": "\"Heavenly Father…",
+            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\"\n\"Come, I'll kick your ass.\"",
             "nextBlock": 3,
             "pathId": -2751798553862275875,
             "blockIdx": 2
@@ -27,12 +27,12 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なんっかちげーな。もーちっとこう……\r\n……『ブチカマすぜぇぇ！！』",
-            "enText": "Something's not right. It's a bit \nmore like … 'I'm a buttkicker!",
+            "enText": "Hmm, that feels off. It should be\nmore like... \"I'm gonna kick your ass!\"",
             "nextBlock": 4,
             "choices": [
                 {
                     "jpText": "ブチカマ……？",
-                    "enText": "Butikama…?",
+                    "enText": "Kick my ass...?",
                     "nextBlock": 4
                 }
             ],
@@ -43,7 +43,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "――ハッ！\r\nアアアアンタ、いつの間に……！",
-            "enText": "—Ha! Aaah antah, when did you…!",
+            "enText": "--Woah!\nS-since when have you been here?",
             "nextBlock": 5,
             "pathId": 5605984693871499806,
             "blockIdx": 4
@@ -52,7 +52,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "つーか、まてまて誰にも言うなよ！？\r\nカッコつけの練習見られるとかダセェだろ！？",
-            "enText": "I mean, come on, don't tell anyone! \nIt's not cool for them to see you \npractising your coolness!",
+            "enText": "I mean, don't tell anyone about this!\nBeing seen practicing cool phrases\nwould be seriously lame.",
             "nextBlock": 6,
             "pathId": -4716578934516563664,
             "blockIdx": 5
@@ -61,17 +61,17 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "それに、本当はもっとカッケェんだ。\r\n今のは全然仕上がってねーの！",
-            "enText": "And it's actually much cooler. \nIt's not finished at all!",
+            "enText": "The real deal's much cooler too.\nI haven't managed to get it down\nat all yet.",
             "nextBlock": 7,
             "choices": [
                 {
                     "jpText": "何のセリフなんだ？",
-                    "enText": "What's the line?",
+                    "enText": "What's that phrase from?",
                     "nextBlock": 7
                 },
                 {
                     "jpText": "何のセリフなの？",
-                    "enText": "What's the line?",
+                    "enText": "What's that phrase from?",
                     "nextBlock": 7
                 }
             ],
@@ -82,7 +82,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ああ、俺の好きな不良漫画のワンシーンでさ、\r\n下剋上を誓って、トップに宣戦布告すんだよ。",
-            "enText": "Yeah, there's a scene in one of my favorite \ndelinquent comics where she declares war on \nthe top, vowing to rise above the rest.",
+            "enText": "It's a phrase from a\ndelinquent manga that I like.\nIn that scene, the main character\ndeclares that he'll overthrow the top.",
             "nextBlock": 8,
             "pathId": -5823152948019756289,
             "blockIdx": 7
@@ -91,7 +91,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！』\r\nってなぁ！　くぅ～～～、カッケェ～～ッ！",
-            "enText": "\"Heavenly Father…\" Yeah! That's so cool!",
+            "enText": "So he's like \"I'm gonna kick your ass!\"\nMan, he's seriously so cool!",
             "nextBlock": 9,
             "pathId": -4401138221719148632,
             "blockIdx": 8
@@ -100,17 +100,17 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "でもさ、俺が言うとなんーか違うっつーか……\r\nワイルドさが足りねーのかなぁ、うーん……。",
-            "enText": "But when I say it, it's not quite the same. \n… I'm not sure it's wild enough…",
+            "enText": "But it doesn't feel right when I say it.\nMaybe I'm lacking wildness...",
             "nextBlock": 10,
             "choices": [
                 {
                     "jpText": "見た目をワイルドにしてみたら？",
-                    "enText": "Why not make it look wild?",
+                    "enText": "How about looking more wild?",
                     "nextBlock": 10
                 },
                 {
                     "jpText": "ワイルドなポーズをとってみたら？",
-                    "enText": "Why not strike a wild pose?",
+                    "enText": "How about striking a wild pose?",
                     "nextBlock": 14
                 }
             ],
@@ -121,7 +121,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "見た目を……！　その手があったか！\r\n確かに、あの漫画のヤツら超ムキムキだぜ！",
-            "enText": "Look…! That's a good idea! You're right, \nthose guys in the comics are super muscular!",
+            "enText": "Oh, I didn't consider looking wild yet.\nThinking of it, everyone in the\nmanga is really muscular too!",
             "nextBlock": 11,
             "pathId": -1067756012550727100,
             "blockIdx": 10
@@ -130,7 +130,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ムキムキになりゃ、ムキムキの見てる世界が\r\nわかるかもしんねぇ！",
-            "enText": "Maybe when you're puffed up you'll see the \nworld as puffed up people see it!",
+            "enText": "If I become really muscular too,\nmaybe I'll understand the way\nbuff people see the world better!",
             "nextBlock": 12,
             "pathId": -7760042973725619736,
             "blockIdx": 11
@@ -139,7 +139,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よっしゃわかった！　ちょっとムキムキに\r\nなってくるわ！　サンキュー！",
-            "enText": "All right, all right! I'm going to go get \nmyself a bit puffed up! Thank you!",
+            "enText": "Okay, got it! I'm gonna go\nget muscular too! Thanks!",
             "nextBlock": 13,
             "pathId": -5165921303071080669,
             "blockIdx": 12
@@ -148,7 +148,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "その後、ウオッカがジムにて、かなり熱心に\r\n筋トレをしていたという噂を聞いた。",
-            "enText": "Afterwards, I heard a rumour that \nVodka had been doing some serious \nmuscle training in the gym.",
+            "enText": "After that, I heard about how\nVodka feverously trained at the gym.",
             "nextBlock": -1,
             "pathId": 4728923334065708207,
             "blockIdx": 13
@@ -157,7 +157,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ワイルドなポーズか……。\r\n確かに、カッケェポーズでキめてたな……。",
-            "enText": "A wild pose… You're right, it's a cool pose…",
+            "enText": "Striking a cool pose, huh...\nYeah, I think that could work.",
             "nextBlock": 15,
             "pathId": -5901416184483430351,
             "blockIdx": 14
@@ -166,7 +166,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "こうか？　それともこう？　こっちがいいか？\r\n意外とポーズとるの、筋肉使うな！？",
-            "enText": "Like this? Or like this? Do you \nprefer this? It takes more muscles \nto pose than you think!",
+            "enText": "Like this? Or more like this?\nWhat do you think about this?\nWoah, striking a pose uses more\nmuscles than I expected!",
             "nextBlock": 16,
             "pathId": 6551231938462432627,
             "blockIdx": 15
@@ -175,7 +175,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スッゲーテンション上がってきたぜ……！\r\nちょっと鏡取ってくる！　サンキューな！",
-            "enText": "I'm getting really excited…! I'll \nget the mirror! Thanks, man!",
+            "enText": "Alright, now I'm pumped! Time to go\ncheck this out in a mirror! Thanks!",
             "nextBlock": 17,
             "pathId": -8243106386738906873,
             "blockIdx": 16
@@ -184,7 +184,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ウオッカのポーズの研究は、\r\n夜が更けるまで熱心に行われたようだった。",
-            "enText": "The study of the pose of the vodka \nseemed to go on enthusiastically \nuntil late into the night.",
+            "enText": "And so, Vodka enthusiastically\npracticed posing late into the night.",
             "nextBlock": -1,
             "pathId": 3346411762792462372,
             "blockIdx": 17

--- a/translations/story/80/1008/002 (大通りの強敵).json
+++ b/translations/story/80/1008/002 (大通りの強敵).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある休日、出かける途中に\r\n校門前を通りかかると――",
-            "enText": "On a day off, while I was\nwalking past the school gate...",
+            "enText": "On a day off, while I was walking\npast the school gate...",
             "nextBlock": 2,
             "pathId": -8270600719711619383,
             "blockIdx": 1
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "チ、チクショー……早くいかねーと\r\nバイク写真集売り切れちまうってのに……！",
-            "enText": "Damn it...if I don't hurry up,\nthey'll sell out of bike photo books!",
+            "enText": "Damn it...if I don't hurry up, they'll sell\nout of bike photo books!",
             "nextBlock": 7,
             "pathId": 6026270507745678907,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なあ、アンタ！　大通りの軟派なヤツら\r\n避ける方法、なんか知らねーか！？",
-            "enText": "Hey, you! Do you have any idea\nhow to avoid running into guys\ntrying to pick up girls in public?",
+            "enText": "Hey, you! Do you have any idea how\nto avoid running into guys trying\nto pick up girls in public?",
             "nextBlock": 8,
             "choices": [
                 {
@@ -84,7 +84,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "脇道……！　そうだ、\r\nほかに道があること忘れてた！",
-            "enText": "A side street? You're right, I totally\nforgot I could just take another way!",
+            "enText": "A side street? You're right, I totally forgot\nI could just take another way!",
             "nextBlock": 9,
             "pathId": -4059325463002486051,
             "blockIdx": 8
@@ -111,7 +111,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……一応言っとっけど、別にキ……が\r\n怖ぇわけじゃねーぞ！　勘違いすんなよ！",
-            "enText": "Just so you know though, it's not\nlike I'm scared of ki-.. being hit on!\nDon't misunderstand!",
+            "enText": "Just so you know though, it's not\nlike I'm scared of ki-.. being hit\non! Don't misunderstand!",
             "nextBlock": -1,
             "pathId": -675035334323726827,
             "blockIdx": 11
@@ -120,7 +120,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "全力疾走……！\r\n見ちまう前に、走り抜けろってことか！？",
-            "enText": "Running as fast as I can...\nSo that they don't even get\na chance to approach me?",
+            "enText": "Running as fast as I can... So that they\ndon't even get a chance to approach me?",
             "nextBlock": 13,
             "pathId": 4914256322229187976,
             "blockIdx": 12
@@ -129,7 +129,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや、俺ならやれる！　やってやらぁ！\r\n光より速く駆けりゃいい話だ！",
-            "enText": "Yeah, I'm sure I can do that!\nI'll dash by them faster than\nthe speed of light!",
+            "enText": "Yeah, I'm sure I can do that! I'll dash by\nthem faster than the speed of light!",
             "nextBlock": 14,
             "pathId": 8596648460312197017,
             "blockIdx": 13
@@ -138,7 +138,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よっしゃ、そうと決まりゃ怖いモンなしだぜ！\r\nサンキューな！！",
-            "enText": "Alright, I've got nothing to be\nafraid of if I do that! Thanks!",
+            "enText": "Alright, I've got nothing to be afraid\nof if I do that! Thanks!",
             "nextBlock": 15,
             "pathId": 8600605470322004766,
             "blockIdx": 14
@@ -147,7 +147,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……違う、怖ぇんじゃねぇ、軟派なモンが\r\n嫌いなだけだ！　勘違いすんなよ！",
-            "enText": "... I mean, not like I'm scared!\nI just dislike getting hit on,\ndon't misunderstand!",
+            "enText": "... I mean, not like I'm scared! I just\ndislike getting hit on, don't misunderstand!",
             "nextBlock": -1,
             "pathId": -2539076437391671355,
             "blockIdx": 15

--- a/translations/story/80/1008/002 (大通りの強敵).json
+++ b/translations/story/80/1008/002 (大通りの強敵).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある休日、出かける途中に\r\n校門前を通りかかると――",
-            "enText": "One day, on my way out on holiday, \nI passed by the school gate.",
+            "enText": "On a day off, while I was\nwalking past the school gate...",
             "nextBlock": 2,
             "pathId": -8270600719711619383,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "うひゃあああああああああー！！",
-            "enText": "Oooohhhh!",
+            "enText": "Aaaaaaaaaaaah!!",
             "nextBlock": 3,
             "pathId": -4295276767313002516,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ままま街中で、キ、キ……なんて軟派なこと\r\nしてんじゃねぇバッカヤローーー！",
-            "enText": "Don't be a softy and go to … in the street!",
+            "enText": "Don't ki- I mean, pick up girls\nin plain view, you idiots!",
             "nextBlock": 4,
             "pathId": -6005040925501855072,
             "blockIdx": 3
@@ -36,7 +36,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "んがぁっ！？",
-            "enText": "What?",
+            "enText": "Ugh!?",
             "nextBlock": 5,
             "pathId": -7757871341574277129,
             "blockIdx": 4
@@ -45,7 +45,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "は、鼻血でだ……！",
-            "enText": "It's a bloody nose…!",
+            "enText": "M-my nose is bleeding...",
             "nextBlock": 6,
             "pathId": 4677550291868902974,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "チ、チクショー……早くいかねーと\r\nバイク写真集売り切れちまうってのに……！",
-            "enText": "Damn it… we'd better get a move on or \nthey'll sell out of motorbike photo albums…!",
+            "enText": "Damn it...if I don't hurry up,\nthey'll sell out of bike photo books!",
             "nextBlock": 7,
             "pathId": 6026270507745678907,
             "blockIdx": 6
@@ -63,17 +63,17 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なあ、アンタ！　大通りの軟派なヤツら\r\n避ける方法、なんか知らねーか！？",
-            "enText": "Hey, you! Do you know anything about how to \navoid those soft guys on the main street?",
+            "enText": "Hey, you! Do you have any idea\nhow to avoid running into guys\ntrying to pick up girls in public?",
             "nextBlock": 8,
             "choices": [
                 {
                     "jpText": "脇道を使う",
-                    "enText": "Use the side roads",
+                    "enText": "Use a side street instead",
                     "nextBlock": 8
                 },
                 {
                     "jpText": "全力疾走で向かう",
-                    "enText": "We're going as fast as we can.",
+                    "enText": "Run past them as fast as you can",
                     "nextBlock": 12
                 }
             ],
@@ -84,7 +84,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "脇道……！　そうだ、\r\nほかに道があること忘れてた！",
-            "enText": "Side road…! Oh yeah, I forgot \nthere's another way!",
+            "enText": "A side street? You're right, I totally\nforgot I could just take another way!",
             "nextBlock": 9,
             "pathId": -4059325463002486051,
             "blockIdx": 8
@@ -93,7 +93,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ちっとごちゃごちゃ入り組んでっけど、\r\nしょうがねぇ！　急がば回れだぜ！",
-            "enText": "It's a bit of a mess, but there you go! The \nsooner we get going, the better!",
+            "enText": "That'll get a little cramped, but whatever!\nSlow and steady wins the race!",
             "nextBlock": 10,
             "pathId": -8352417763350295956,
             "blockIdx": 9
@@ -102,7 +102,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よっしゃ、いってくる！！\r\nありがとな！！",
-            "enText": "All right, I'm off! Thanks, man!",
+            "enText": "Alright, I'm gonna go then! Thanks!",
             "nextBlock": 11,
             "pathId": 2374582329015732167,
             "blockIdx": 10
@@ -111,7 +111,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……一応言っとっけど、別にキ……が\r\n怖ぇわけじゃねーぞ！　勘違いすんなよ！",
-            "enText": "… Just so you know, I'm not scared \nof …! Don't get me wrong!",
+            "enText": "Just so you know though, it's not\nlike I'm scared of ki-.. being hit on!\nDon't misunderstand!",
             "nextBlock": -1,
             "pathId": -675035334323726827,
             "blockIdx": 11
@@ -120,7 +120,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "全力疾走……！\r\n見ちまう前に、走り抜けろってことか！？",
-            "enText": "Run as fast as you can…! You're supposed to \nrun through it before you see it!",
+            "enText": "Running as fast as I can...\nSo that they don't even get\na chance to approach me?",
             "nextBlock": 13,
             "pathId": 4914256322229187976,
             "blockIdx": 12
@@ -129,7 +129,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや、俺ならやれる！　やってやらぁ！\r\n光より速く駆けりゃいい話だ！",
-            "enText": "No, I can do it! I can do it! It's all about \nrunning faster than light!",
+            "enText": "Yeah, I'm sure I can do that!\nI'll dash by them faster than\nthe speed of light!",
             "nextBlock": 14,
             "pathId": 8596648460312197017,
             "blockIdx": 13
@@ -138,7 +138,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よっしゃ、そうと決まりゃ怖いモンなしだぜ！\r\nサンキューな！！",
-            "enText": "All right, that's it, we've got \nnothing to fear! Thanks a lot!",
+            "enText": "Alright, I've got nothing to be\nafraid of if I do that! Thanks!",
             "nextBlock": 15,
             "pathId": 8600605470322004766,
             "blockIdx": 14
@@ -147,7 +147,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……違う、怖ぇんじゃねぇ、軟派なモンが\r\n嫌いなだけだ！　勘違いすんなよ！",
-            "enText": "… No, I'm not scared, I just don't like soft \nstuff! Don't get me wrong!",
+            "enText": "... I mean, not like I'm scared!\nI just dislike getting hit on,\ndon't misunderstand!",
             "nextBlock": -1,
             "pathId": -2539076437391671355,
             "blockIdx": 15


### PR DESCRIPTION
This PR adds proper translation for the training events of the "Tracen Academy" (R) Vodka support card.

I don't know whether this linebreaking actually fits ingame as I do not use the patch, all I did was run textprocess (with no replacements) over it.