### PR TITLE
Add Vodka SR support card events

### DIFF
--- a/tl-progress.md
+++ b/tl-progress.md
@@ -1,4 +1,4 @@
-This document gives an overview of translation progress.
+This document gives an overview of translation progress. 
 Note: [deepl](https://www.deepl.com/) is machine translation. These have limited and mostly arbitrary manual edits stemming from fixing common issues.
 Quality varies based on content (speech patterns, topics, etc).
 

--- a/tl-progress.md
+++ b/tl-progress.md
@@ -88,8 +88,8 @@ Sakura Bakushin O | Complete | deepl
 name | progress | translator
 --- | --- | ---
 All except the below (up to 30/12/2021) | Complete | deepl
-Vodka (Tracen Academy) | Complete | [robflop][]
-Vodka (Annoying Observer) | Complete | [robflop][]
+Vodka (R, Tracen Academy) | Complete | [robflop][]
+Vodka (SR, Annoying Observer) | Complete | [robflop][]
 
 # Home Dialogue
 name | progress | translator

--- a/tl-progress.md
+++ b/tl-progress.md
@@ -1,4 +1,4 @@
-This document gives an overview of translation progress.  
+This document gives an overview of translation progress.
 Note: [deepl](https://www.deepl.com/) is machine translation. These have limited and mostly arbitrary manual edits stemming from fixing common issues.
 Quality varies based on content (speech patterns, topics, etc).
 
@@ -87,7 +87,9 @@ Sakura Bakushin O | Complete | deepl
 ## Cards
 name | progress | translator
 --- | --- | ---
-All (up to 30/12/2021) | Complete | deepl
+All except the below (up to 30/12/2021) | Complete | deepl
+Vodka (Tracen Academy) | Complete | [robflop][]
+Vodka (Annoying Observer) | Complete | [robflop][]
 
 # Home Dialogue
 name | progress | translator

--- a/tl-progress.md
+++ b/tl-progress.md
@@ -1,4 +1,4 @@
-This document gives an overview of translation progress. 
+This document gives an overview of translation progress.  
 Note: [deepl](https://www.deepl.com/) is machine translation. These have limited and mostly arbitrary manual edits stemming from fixing common issues.
 Quality varies based on content (speech patterns, topics, etc).
 

--- a/translations/story/82/0039/001 (黄昏サボタージュ).json
+++ b/translations/story/82/0039/001 (黄昏サボタージュ).json
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あー、うっせーな！\r\n集中して見られねーだろ！",
-            "enText": "Ugh, leave me alone!\nI can't focus on watching!",
+            "enText": "Ugh, leave me alone! I can't\nfocus on watching!",
             "nextBlock": 3,
             "pathId": -1032555894439955970,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "今は掃除の時間でしょっ！\r\nバイクレースなんて録画でもしときなさいよ！",
-            "enText": "We're on cleaning duty right now!\nJust watch a recording\nof that bike race!",
+            "enText": "We're on cleaning duty right now! Just watch\na recording of that bike race!",
             "nextBlock": 4,
             "pathId": 755144075983670730,
             "blockIdx": 3
@@ -45,7 +45,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "な～にがロマンよ！　偉そうなこと言うのは\r\nやることやってからにしなさい！",
-            "enText": "What's there to understand?\nYou can talk like that after you're done\nwith what you're supposed to be doing!",
+            "enText": "What's there to understand? You can talk like\nthat after you're done with what you're\nsupposed to be doing!",
             "nextBlock": 6,
             "pathId": 7618667823475009207,
             "blockIdx": 5
@@ -63,7 +63,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "掃除はやりたいヤツがやりゃいいだろ！",
-            "enText": "Do your cleaning alone\nif you wanna do it that much!",
+            "enText": "Do your cleaning alone if you\nwanna do it that much!",
             "nextBlock": 8,
             "pathId": 5162077456848096475,
             "blockIdx": 7
@@ -81,7 +81,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "それから校舎裏でウオッカを見かけた。\r\n彼女のスマホから、バイクレースの\n白熱した実況が流れている。",
-            "enText": "After that, I spotted Vodka\nbehind the school building.\nThe energetic sound of bike engines\npoured out from her smartphone.",
+            "enText": "After that, I spotted Vodka behind the school\nbuilding. The energetic sound of bike engines\npoured out from her smartphone.",
             "nextBlock": 10,
             "pathId": -2010334043679495024,
             "blockIdx": 9
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あぁー、くそ！　なんだってんだ……！\r\nこんなはずじゃ……あぁぁー、もう！",
-            "enText": "Damn it...! Why do I feel like this?\nThis isn't how it was supposed to be...!",
+            "enText": "Damn it...! Why do I feel like this? This\nisn't how it was supposed to be...!",
             "nextBlock": 12,
             "choices": [
                 {
@@ -138,7 +138,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "な～にがロマンよ！　偉そうなこと言うのは\r\nやることやってからにしなさい！",
-            "enText": "What's there to understand?\nYou can talk like that after you're done\nwith what you're supposed to be doing!",
+            "enText": "What's there to understand? You can talk like\nthat after you're done with what you're\nsupposed to be doing!",
             "nextBlock": 15,
             "pathId": -6309102875795735290,
             "blockIdx": 14
@@ -147,7 +147,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "アイツの言う通りだ……。\r\nやらなきゃならねーこと投げ出すなんて――",
-            "enText": "...She's completely right.\nDitching things you should do...",
+            "enText": "...She's completely right. Ditching\nthings you should do...",
             "nextBlock": 16,
             "pathId": -3088162865032064386,
             "blockIdx": 15
@@ -156,7 +156,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ハンパすぎんだろ……！\r\nダサすぎんだろ……ちくしょー！",
-            "enText": "It's way too half-assed!\nI'm seriously lame... damn it!",
+            "enText": "It's way too half-assed! I'm\nseriously lame... damn it!",
             "nextBlock": 17,
             "pathId": 3481697921921330977,
             "blockIdx": 16
@@ -186,7 +186,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "…………だな。\r\nそれしかねーよな！",
-            "enText": "... Yeah, you're right.\nThat's what I should do.",
+            "enText": "... Yeah, you're right. That's\nwhat I should do.",
             "nextBlock": 19,
             "pathId": 8876938363864511224,
             "blockIdx": 18
@@ -195,7 +195,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "反省してるっ！　アイツにも悪ぃことした！\r\n2度とこんなダセー真似はしねえっ！",
-            "enText": "I'm gonna make it up to her for sure!\nAnd I'll never be this lame again, either.",
+            "enText": "I'm gonna make it up to her for sure! And\nI'll never be this lame again, either.",
             "nextBlock": 20,
             "pathId": -3227448119379770002,
             "blockIdx": 19
@@ -204,7 +204,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "と、そこへ――",
-            "enText": "Right when we were about\nto return to the classroom--",
+            "enText": "Right when we were about to\nreturn to the classroom--",
             "nextBlock": 21,
             "pathId": 6625004654339446017,
             "blockIdx": 20
@@ -213,7 +213,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はいはい、どいてどいて。\r\nゴミ捨ての邪魔だから。",
-            "enText": "Yeah, yeah. Move it, you're in\nthe way of the trash container.",
+            "enText": "Yeah, yeah. Move it, you're in the\nway of the trash container.",
             "nextBlock": 22,
             "pathId": 1047714431026897678,
             "blockIdx": 21
@@ -222,7 +222,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スカーレット！\r\nい、今の聞いてたのかよ！？",
-            "enText": "Scarlet!\nD-did you hear what I just said?",
+            "enText": "Scarlet! D-did you hear what I just said?",
             "nextBlock": 23,
             "pathId": -5068198949885098693,
             "blockIdx": 22
@@ -258,7 +258,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はいはい。……で、アイツって誰なのよ？",
-            "enText": "Yeah, yeah.\n...So, who's this someone?",
+            "enText": "Yeah, yeah. ...So, who's this someone?",
             "nextBlock": 27,
             "pathId": 3665815265002429655,
             "blockIdx": 26
@@ -267,7 +267,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "そ、その話はもういーじゃねーか！\r\nアイツはアイツだよ！",
-            "enText": "Enough of that already!\nSomeone's someone!",
+            "enText": "Enough of that already! Someone's someone!",
             "nextBlock": 28,
             "pathId": -6226635499037709515,
             "blockIdx": 27
@@ -276,7 +276,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "えー、全然わかんないんだけど？\r\nアンタの口からはっきり聞きたいな～？",
-            "enText": "I have absolutely no clue whoever\nyou could be talking about though...\nC'mon, I want to hear\nyou say it explicitly!",
+            "enText": "I have absolutely no clue whoever you could\nbe talking about though... C'mon, I want to\nhear you say it explicitly!",
             "nextBlock": 29,
             "pathId": -7956324498734328804,
             "blockIdx": 28
@@ -303,7 +303,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺は逃げねえ！　ビシッと謝ってやる！",
-            "enText": "I'm not gonna run away!\nI'm gonna properly apologize to her!",
+            "enText": "I'm not gonna run away! I'm gonna\nproperly apologize to her!",
             "nextBlock": 32,
             "pathId": -8249517779102871705,
             "blockIdx": 31
@@ -312,7 +312,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "と、そこへ――",
-            "enText": "Right when we were about\nto return to the classroom--",
+            "enText": "Right when we were about to\nreturn to the classroom--",
             "nextBlock": 33,
             "pathId": -1445520822394854448,
             "blockIdx": 32
@@ -321,7 +321,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "アンタ、こんなとこにいたの？\r\nで、誰がなにを謝るって？",
-            "enText": "So this is where you've been?\nAnd what's this about someone\napologizing for something?",
+            "enText": "So this is where you've been? And what's this\nabout someone apologizing for something?",
             "nextBlock": 34,
             "pathId": 2441965058879445788,
             "blockIdx": 33
@@ -330,7 +330,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スカーレット！　ちょうどよかった！\r\nあ、あのよ……！",
-            "enText": "Scarlet! Perfect timing.\nU-um, so...!",
+            "enText": "Scarlet! Perfect timing. U-um, so...!",
             "nextBlock": 35,
             "pathId": 4111051617905567172,
             "blockIdx": 34
@@ -339,7 +339,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "掃除サボって悪かった……！\r\n自分のこと考えてばっかで、その……。",
-            "enText": "I'm sorry for ditching cleaning duty.\nOnly thinking about myself like that...",
+            "enText": "I'm sorry for ditching cleaning duty. Only\nthinking about myself like that...",
             "nextBlock": 36,
             "pathId": -413747710141347246,
             "blockIdx": 35
@@ -357,7 +357,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "当たり前だろ！　腰抜かすくらい\r\nキレイにしてやるよ！",
-            "enText": "Of course! When I'm done, the\nclassroom will be clean\nenough to blind you!",
+            "enText": "Of course! When I'm done, the classroom will\nbe clean enough to blind you!",
             "nextBlock": 38,
             "pathId": 3937740679662264900,
             "blockIdx": 37
@@ -366,7 +366,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よーし、やるぞー！\r\nオマエは拭き掃除、俺が掃き掃除な。",
-            "enText": "Alright, let's do this!\nYou wipe the room,\nand I'll sweep the floor!",
+            "enText": "Alright, let's do this! You wipe the room,\nand I'll sweep the floor!",
             "nextBlock": 39,
             "pathId": 5889443046115172597,
             "blockIdx": 38
@@ -375,7 +375,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "さっきまでサボってたヤツが偉そうに……。",
-            "enText": "For someone that was just slacking\noff, you sure are taking charge now...",
+            "enText": "For someone that was just slacking off, you\nsure are taking charge now...",
             "nextBlock": 40,
             "pathId": -2552116722999487482,
             "blockIdx": 39
@@ -384,7 +384,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "あれ、そういえばバイクレースの\r\n中継は終わったの？",
-            "enText": "Oh, right. What about that bike race?\nIs that already over?",
+            "enText": "Oh, right. What about that bike\nrace? Is that already over?",
             "nextBlock": 41,
             "pathId": 3126675204085017802,
             "blockIdx": 40
@@ -393,7 +393,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや、まだやってるぜ。\r\nでも今はそれどころじゃねーからな。",
-            "enText": "No, it's still going on.\nBut that's not important right now.",
+            "enText": "No, it's still going on. But that's\nnot important right now.",
             "nextBlock": 42,
             "pathId": 1458447945309386426,
             "blockIdx": 41
@@ -402,7 +402,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "へえ……やけに真面目じゃない。\r\nなんか悪いものでも食べたわけ？",
-            "enText": "Huh, you sure are being obedient now.\nDid you eat something bad?",
+            "enText": "Huh, you sure are being obedient\nnow. Did you eat something bad?",
             "nextBlock": 43,
             "pathId": -4469646238871257671,
             "blockIdx": 42
@@ -411,7 +411,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "んなもん食べるか。\r\n俺はケジメつけたいんだよ。",
-            "enText": "I didn't eat anything.\nI'm just trying to get my priorities straight.",
+            "enText": "I didn't eat anything. I'm just trying to get\nmy priorities straight.",
             "nextBlock": 44,
             "pathId": 6892086362447663255,
             "blockIdx": 43
@@ -420,7 +420,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ハンパなままじゃ、カッコいいもんに\r\n憧れる資格がねーからな！",
-            "enText": "I can't be cool if I do things\nin a half-assed way, after all!",
+            "enText": "I can't be cool if I do things in a\nhalf-assed way, after all!",
             "nextBlock": 45,
             "pathId": 842931133127544634,
             "blockIdx": 44
@@ -456,7 +456,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "ウオッカがホウキを激しく動かすと、\r\n大量の埃が宙を舞った……。",
-            "enText": "As Vodka violently swung the broom, a lot of \ndust starting flying through the air...",
+            "enText": "As Vodka violently swung the broom, a lot of \n dust starting flying through the air...",
             "nextBlock": 49,
             "pathId": 7922618632625908153,
             "blockIdx": 48
@@ -474,7 +474,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "なにやってんのよ！\r\nアンタ散らかしに戻って来たわけ！？",
-            "enText": "What are you doing!? Did you come back to make a mess again!?",
+            "enText": "What are you doing!? Did you come\nback to make a mess again!?",
             "nextBlock": 51,
             "pathId": 1118590992372766611,
             "blockIdx": 50
@@ -483,7 +483,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "窓開けてホコリを風に流すんだよ！\r\nどうだ、天才だろ！",
-            "enText": "Just open the window and watch the wind blow the\ndust away! Genius, right?",
+            "enText": "Just open the window and watch the wind blow\nthe dust away! Genius, right?",
             "nextBlock": 52,
             "pathId": -1001687021712860152,
             "blockIdx": 51
@@ -492,7 +492,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "バカの発想だし、外にホコリを出さないっ！\r\nアンタってばほんと……！！",
-            "enText": "That's a stupid idea, all it does is spread the dust outside!\nI really can't believe you...!",
+            "enText": "That's a stupid idea, all it does\nis spread the dust outside! I really\ncan't believe you...!",
             "nextBlock": 53,
             "choices": [
                 {

--- a/translations/story/82/0039/001 (黄昏サボタージュ).json
+++ b/translations/story/82/0039/001 (黄昏サボタージュ).json
@@ -9,7 +9,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "トレーナー室へ向かう途中、言い争う声と\r\nともに2人のウマ娘が教室から出てきた。",
-            "enText": "On the way to the trainer's office, two \ngirls came out of the classroom, arguing \nwith each other.",
+            "enText": "As I was walking to the trainer room,\nI spotted two horsegirls arguing\nin front of a classroom.",
             "nextBlock": 2,
             "pathId": 4611211369726719276,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あー、うっせーな！\r\n集中して見られねーだろ！",
-            "enText": "Oh, shut up! I can't concentrate \non what I'm doing!",
+            "enText": "Ugh, leave me alone!\nI can't focus on watching!",
             "nextBlock": 3,
             "pathId": -1032555894439955970,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "今は掃除の時間でしょっ！\r\nバイクレースなんて録画でもしときなさいよ！",
-            "enText": "It's cleaning time! You should \nbe recording bike races!",
+            "enText": "We're on cleaning duty right now!\nJust watch a recording\nof that bike race!",
             "nextBlock": 4,
             "pathId": 755144075983670730,
             "blockIdx": 3
@@ -36,7 +36,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "生中継じゃなきゃ意味ねえんだよ！\r\nオマエはロマンをわかってねーな。",
-            "enText": "If it's not live, it's useless! You don't \nunderstand romance, do you?",
+            "enText": "There's no point if I don't watch it live!\nYou just don't understand!",
             "nextBlock": 5,
             "pathId": 8104941857216124430,
             "blockIdx": 4
@@ -45,7 +45,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "な～にがロマンよ！　偉そうなこと言うのは\r\nやることやってからにしなさい！",
-            "enText": "What's the point of romance? You can't talk \nbig until you've done what you've done!",
+            "enText": "What's there to understand?\nYou can talk like that after you're done\nwith what you're supposed to be doing!",
             "nextBlock": 6,
             "pathId": 7618667823475009207,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "う……！！\r\nぅ……う、うるせーなぁ！！",
-            "enText": "U…! U… U, shut up!",
+            "enText": "Ugh... Shut up!",
             "nextBlock": 7,
             "pathId": -9087740916410957915,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "掃除はやりたいヤツがやりゃいいだろ！",
-            "enText": "Whoever wants to do the cleaning can do it!",
+            "enText": "Do your cleaning alone\nif you wanna do it that much!",
             "nextBlock": 8,
             "pathId": 5162077456848096475,
             "blockIdx": 7
@@ -72,7 +72,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "丸投げするつもり！？\r\nもうっ……バカ！！",
-            "enText": "You're going to throw it all \naway! God… you idiot!",
+            "enText": "Wha- don't bail on me! You... idiot!",
             "nextBlock": 9,
             "pathId": -491651667433631708,
             "blockIdx": 8
@@ -81,7 +81,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "それから校舎裏でウオッカを見かけた。\r\n彼女のスマホから、バイクレースの\n白熱した実況が流れている。",
-            "enText": "Then I saw Vodka at the back of the school. \nHer phone is playing a live stream of a \nheated motorbike race.",
+            "enText": "After that, I spotted Vodka\nbehind the school building.\nThe energetic sound of bike engines\npoured out from her smartphone.",
             "nextBlock": 10,
             "pathId": -2010334043679495024,
             "blockIdx": 9
@@ -90,7 +90,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "しかし、その盛り上がりとは反対に\r\nウオッカはどこか浮かない表情をしていた。",
-            "enText": "However, despite all the excitement, Vodka \nwas not looking too happy.",
+            "enText": "Contrary to that, Vodka seemed\nsomewhat absentminded.",
             "nextBlock": 11,
             "pathId": 2601586335139856028,
             "blockIdx": 10
@@ -99,17 +99,17 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あぁー、くそ！　なんだってんだ……！\r\nこんなはずじゃ……あぁぁー、もう！",
-            "enText": "Oh, shit! What the hell…! It's \nnot supposed to be… Oh, God!",
+            "enText": "Damn it...! Why do I feel like this?\nThis isn't how it was supposed to be...!",
             "nextBlock": 12,
             "choices": [
                 {
                     "jpText": "なんだか楽しくなさそうだな",
-                    "enText": "That doesn't sound like much fun.",
+                    "enText": "You don't look like you're having fun",
                     "nextBlock": 12
                 },
                 {
                     "jpText": "なんだか楽しくなさそうだね",
-                    "enText": "You don't sound like you're having much fun.",
+                    "enText": "You don't look like you're having fun",
                     "nextBlock": 12
                 }
             ],
@@ -120,7 +120,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "アンタ、さっき廊下にいた……。\r\nイヤなとこ見られちまったな。",
-            "enText": "You were just in the hallway… I \ndon't like the way you look.",
+            "enText": "Oh, you were at the classroom too.\nSorry you had to see that.",
             "nextBlock": 13,
             "pathId": -7000345210982799076,
             "blockIdx": 12
@@ -129,7 +129,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……スカーレットの言葉が、\r\nずっと頭ん中グルグルしててよ。",
-            "enText": "… Scarlett's words have been \ngoing through my head.",
+            "enText": "It's just... I can't stop thinking\nabout what Scarlet said.",
             "nextBlock": 14,
             "pathId": 1204320833524539501,
             "blockIdx": 13
@@ -138,7 +138,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "な～にがロマンよ！　偉そうなこと言うのは\r\nやることやってからにしなさい！",
-            "enText": "What's the point of romance? You can't talk \nbig until you've done what you've done!",
+            "enText": "What's there to understand?\nYou can talk like that after you're done\nwith what you're supposed to be doing!",
             "nextBlock": 15,
             "pathId": -6309102875795735290,
             "blockIdx": 14
@@ -147,7 +147,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "アイツの言う通りだ……。\r\nやらなきゃならねーこと投げ出すなんて――",
-            "enText": "She's right… I can't believe I \nthrew away what I had to do.",
+            "enText": "...She's completely right.\nDitching things you should do...",
             "nextBlock": 16,
             "pathId": -3088162865032064386,
             "blockIdx": 15
@@ -156,7 +156,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ハンパすぎんだろ……！\r\nダサすぎんだろ……ちくしょー！",
-            "enText": "You're too lame…! You're \ntoo lame for this… shit!",
+            "enText": "It's way too half-assed!\nI'm seriously lame... damn it!",
             "nextBlock": 17,
             "pathId": 3481697921921330977,
             "blockIdx": 16
@@ -165,17 +165,17 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "アイツも……きっと、呆れてるよな……。",
-            "enText": "I'm sure she's… stunned, too…",
+            "enText": "I'm sure she's fed up with me too...",
             "nextBlock": 18,
             "choices": [
                 {
                     "jpText": "反省の態度を見せよう！",
-                    "enText": "Let's show some remorse!",
+                    "enText": "You should make it up to her",
                     "nextBlock": 18
                 },
                 {
                     "jpText": "素直に謝ればいい",
-                    "enText": "Just be honest and apologise.",
+                    "enText": "Be honest and apologize to her",
                     "nextBlock": 30
                 }
             ],
@@ -186,7 +186,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "…………だな。\r\nそれしかねーよな！",
-            "enText": "It's… It's the only way to go!",
+            "enText": "... Yeah, you're right.\nThat's what I should do.",
             "nextBlock": 19,
             "pathId": 8876938363864511224,
             "blockIdx": 18
@@ -195,7 +195,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "反省してるっ！　アイツにも悪ぃことした！\r\n2度とこんなダセー真似はしねえっ！",
-            "enText": "I'm sorry! I'm sorry for what I \ndid to her! I'll never do anything \nstupid like this again!",
+            "enText": "I'm gonna make it up to her for sure!\nAnd I'll never be this lame again, either.",
             "nextBlock": 20,
             "pathId": -3227448119379770002,
             "blockIdx": 19
@@ -204,7 +204,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "と、そこへ――",
-            "enText": "And then—",
+            "enText": "Right when we were about\nto return to the classroom--",
             "nextBlock": 21,
             "pathId": 6625004654339446017,
             "blockIdx": 20
@@ -213,7 +213,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はいはい、どいてどいて。\r\nゴミ捨ての邪魔だから。",
-            "enText": "Yeah, yeah, yeah, move over, move over. \nYou're in the way of the rubbish.",
+            "enText": "Yeah, yeah. Move it, you're in\nthe way of the trash container.",
             "nextBlock": 22,
             "pathId": 1047714431026897678,
             "blockIdx": 21
@@ -222,7 +222,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スカーレット！\r\nい、今の聞いてたのかよ！？",
-            "enText": "Scarlett! Hey, did you hear that?",
+            "enText": "Scarlet!\nD-did you hear what I just said?",
             "nextBlock": 23,
             "pathId": -5068198949885098693,
             "blockIdx": 22
@@ -231,7 +231,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "ふん、勝手に聞こえてきたのよ。\r\nアイツにも悪いことした、だっけ？",
-            "enText": "Hmm, I heard it all on my own. I've \nbeen bad to her, haven't I?",
+            "enText": "Hmph, I just happened to overhear.\nMaking it up to someone, was it?",
             "nextBlock": 24,
             "pathId": 8937566586532643899,
             "blockIdx": 23
@@ -240,7 +240,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "で、そのアイツって誰のこと？",
-            "enText": "And who is this \"she\"?",
+            "enText": "So, who's this someone?",
             "nextBlock": 25,
             "pathId": -3322948918178460609,
             "blockIdx": 24
@@ -249,7 +249,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ぐ……わ、わかってるくせに聞くんじゃねー！\r\nそれよりゴミ袋貸せよ！　俺も掃除するっ！",
-            "enText": "… You know what I'm talking about! I'll \nclean it too! I'll clean it too!",
+            "enText": "Ugh.. don't pretend like you don't know!\nLet's just get this cleaning done! I'll help.",
             "nextBlock": 26,
             "pathId": 1198264626711665072,
             "blockIdx": 25
@@ -258,7 +258,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はいはい。……で、アイツって誰なのよ？",
-            "enText": "Yes, yes. Who's that guy…?",
+            "enText": "Yeah, yeah.\n...So, who's this someone?",
             "nextBlock": 27,
             "pathId": 3665815265002429655,
             "blockIdx": 26
@@ -267,7 +267,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "そ、その話はもういーじゃねーか！\r\nアイツはアイツだよ！",
-            "enText": "Oh, come on, let's not talk about that! \nThat's her, that's her!",
+            "enText": "Enough of that already!\nSomeone's someone!",
             "nextBlock": 28,
             "pathId": -6226635499037709515,
             "blockIdx": 27
@@ -276,7 +276,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "えー、全然わかんないんだけど？\r\nアンタの口からはっきり聞きたいな～？",
-            "enText": "Well, I don't understand it at all, do you? \nI want to hear it clearly from you!",
+            "enText": "I have absolutely no clue whoever\nyou could be talking about though...\nC'mon, I want to hear\nyou say it explicitly!",
             "nextBlock": 29,
             "pathId": -7956324498734328804,
             "blockIdx": 28
@@ -285,7 +285,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "だぁぁあああっ！\r\nぜってぇ言うもんかぁぁ～～～！！",
-            "enText": "Dahhh! I'm not going to say anything!",
+            "enText": "Ugh... I'm definitely not telling you!",
             "nextBlock": -1,
             "pathId": 4477972611750735235,
             "blockIdx": 29
@@ -294,7 +294,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "できっかな……いや、やるしかねえよな。",
-            "enText": "Dekikikana… No, we have to do it.",
+            "enText": "Apologize to her, huh...\nYeah, I really have to.",
             "nextBlock": 31,
             "pathId": -9176640511225669022,
             "blockIdx": 30
@@ -303,7 +303,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺は逃げねえ！　ビシッと謝ってやる！",
-            "enText": "I'm not running away! I'm \ngonna apologize to you!",
+            "enText": "I'm not gonna run away!\nI'm gonna properly apologize to her!",
             "nextBlock": 32,
             "pathId": -8249517779102871705,
             "blockIdx": 31
@@ -312,7 +312,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "と、そこへ――",
-            "enText": "And then—",
+            "enText": "Right when we were about\nto return to the classroom--",
             "nextBlock": 33,
             "pathId": -1445520822394854448,
             "blockIdx": 32
@@ -321,7 +321,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "アンタ、こんなとこにいたの？\r\nで、誰がなにを謝るって？",
-            "enText": "You're here, aren't you? And \nwho's apologising for what?",
+            "enText": "So this is where you've been?\nAnd what's this about someone\napologizing for something?",
             "nextBlock": 34,
             "pathId": 2441965058879445788,
             "blockIdx": 33
@@ -330,7 +330,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スカーレット！　ちょうどよかった！\r\nあ、あのよ……！",
-            "enText": "Scarlet! Just in time! Oh, you know what…!",
+            "enText": "Scarlet! Perfect timing.\nU-um, so...!",
             "nextBlock": 35,
             "pathId": 4111051617905567172,
             "blockIdx": 34
@@ -339,7 +339,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "掃除サボって悪かった……！\r\n自分のこと考えてばっかで、その……。",
-            "enText": "I'm sorry I skipped cleaning…! All I do is \nthink about myself and that…",
+            "enText": "I'm sorry for ditching cleaning duty.\nOnly thinking about myself like that...",
             "nextBlock": 36,
             "pathId": -413747710141347246,
             "blockIdx": 35
@@ -348,7 +348,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はぁ……いいわよ、もう。\r\nその代わり、こっから挽回しなさいよね。",
-            "enText": "Huh… Okay, that's enough. You'll have to \nmake up for it from here on out.",
+            "enText": "...It's fine, don't mention it.\nJust make up for it now.",
             "nextBlock": 37,
             "pathId": 6277683935617232257,
             "blockIdx": 36
@@ -357,7 +357,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "当たり前だろ！　腰抜かすくらい\r\nキレイにしてやるよ！",
-            "enText": "Of course you are! I'm going to make you \nlook so good you'll be sitting on your ass!",
+            "enText": "Of course! When I'm done, the\nclassroom will be clean\nenough to blind you!",
             "nextBlock": 38,
             "pathId": 3937740679662264900,
             "blockIdx": 37
@@ -366,7 +366,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よーし、やるぞー！\r\nオマエは拭き掃除、俺が掃き掃除な。",
-            "enText": "Alright, let's do this! You do the \nwiping, I'll do the sweeping.",
+            "enText": "Alright, let's do this!\nYou wipe the room,\nand I'll sweep the floor!",
             "nextBlock": 39,
             "pathId": 5889443046115172597,
             "blockIdx": 38
@@ -375,7 +375,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "さっきまでサボってたヤツが偉そうに……。",
-            "enText": "The guy who was slacking off \na while ago is a great…",
+            "enText": "For someone that was just slacking\noff, you sure are taking charge now...",
             "nextBlock": 40,
             "pathId": -2552116722999487482,
             "blockIdx": 39
@@ -384,7 +384,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "あれ、そういえばバイクレースの\r\n中継は終わったの？",
-            "enText": "Oh, and by the way, has the \nbike race gone live?",
+            "enText": "Oh, right. What about that bike race?\nIs that already over?",
             "nextBlock": 41,
             "pathId": 3126675204085017802,
             "blockIdx": 40
@@ -393,7 +393,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや、まだやってるぜ。\r\nでも今はそれどころじゃねーからな。",
-            "enText": "No, I'm still working on it. I'm still \nworking on it, but now is not the time.",
+            "enText": "No, it's still going on.\nBut that's not important right now.",
             "nextBlock": 42,
             "pathId": 1458447945309386426,
             "blockIdx": 41
@@ -402,7 +402,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "へえ……やけに真面目じゃない。\r\nなんか悪いものでも食べたわけ？",
-            "enText": "Wow… you're so serious. Did \nyou eat something bad?",
+            "enText": "Huh, you sure are being obedient now.\nDid you eat something bad?",
             "nextBlock": 43,
             "pathId": -4469646238871257671,
             "blockIdx": 42
@@ -411,7 +411,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "んなもん食べるか。\r\n俺はケジメつけたいんだよ。",
-            "enText": "I'm not going to eat that. I'm just \ntrying to settle a score.",
+            "enText": "I didn't eat anything.\nI'm just trying to get my priorities straight.",
             "nextBlock": 44,
             "pathId": 6892086362447663255,
             "blockIdx": 43
@@ -420,7 +420,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ハンパなままじゃ、カッコいいもんに\r\n憧れる資格がねーからな！",
-            "enText": "If you're not good enough, you don't deserve \nto be good enough for anything cool!",
+            "enText": "I can't be cool if I do things\nin a half-assed way, after all!",
             "nextBlock": 45,
             "pathId": 842931133127544634,
             "blockIdx": 44
@@ -429,7 +429,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "……はいはい、いつも通りってわけね。",
-            "enText": "… Yes, yes, yes, it's business as usual.",
+            "enText": "Yeah, yeah... the same as always.",
             "nextBlock": -1,
             "pathId": -4767024818637601236,
             "blockIdx": 45
@@ -438,7 +438,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よーし、オマエは休んでろ！\r\n後は俺が全部やってやる！",
-            "enText": "Alright, you go rest! I'll take \ncare of everything else!",
+            "enText": "Alright, you go rest! I'll take\ncare of everything else!",
             "nextBlock": 47,
             "pathId": 2419272723671180666,
             "blockIdx": 46
@@ -447,7 +447,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どりゃりゃりゃりゃりゃっ！！",
-            "enText": "Rumble, rumble, rumble!",
+            "enText": "Haaaaaaaaah!",
             "nextBlock": 48,
             "pathId": -1363214514306050112,
             "blockIdx": 47
@@ -456,7 +456,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "ウオッカがホウキを激しく動かすと、\r\n大量の埃が宙を舞った……。",
-            "enText": "As the vodka broom moved violently, a lot of \ndust flew through the air…",
+            "enText": "As Vodka violently swung the broom, a lot of \ndust starting flying through the air...",
             "nextBlock": 49,
             "pathId": 7922618632625908153,
             "blockIdx": 48
@@ -465,7 +465,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "ケホッケホッ！　ストップ、ストーップ！！",
-            "enText": "Que-ho-ho! Stoop, stoop!",
+            "enText": "Cough, cough! Stop, stooop!",
             "nextBlock": 50,
             "pathId": -2181314214596319937,
             "blockIdx": 49
@@ -474,7 +474,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "なにやってんのよ！\r\nアンタ散らかしに戻って来たわけ！？",
-            "enText": "What are you doing here? You've \ncome back to make a mess!",
+            "enText": "What are you doing!? Did you come back to make a mess again!?",
             "nextBlock": 51,
             "pathId": 1118590992372766611,
             "blockIdx": 50
@@ -483,7 +483,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "窓開けてホコリを風に流すんだよ！\r\nどうだ、天才だろ！",
-            "enText": "Open the window and let the wind blow the \ndust away! How about that, genius!",
+            "enText": "Just open the window and watch the wind blow the\ndust away! Genius, right?",
             "nextBlock": 52,
             "pathId": -1001687021712860152,
             "blockIdx": 51
@@ -492,17 +492,17 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "バカの発想だし、外にホコリを出さないっ！\r\nアンタってばほんと……！！",
-            "enText": "It's a stupid idea and it keeps \nthe dust out! You're a real…!",
+            "enText": "That's a stupid idea, all it does is spread the dust outside!\nI really can't believe you...!",
             "nextBlock": 53,
             "choices": [
                 {
                     "jpText": "やっぱり仲がいいな",
-                    "enText": "I knew we were close.",
+                    "enText": "I knew you were good friends",
                     "nextBlock": 53
                 },
                 {
                     "jpText": "やっぱり仲がいいね",
-                    "enText": "I knew you were good friends.",
+                    "enText": "I knew you were good friends",
                     "nextBlock": 53
                 }
             ],
@@ -513,7 +513,7 @@
             "jpName": "2人",
             "enName": "Both",
             "jpText": "どこがっ！！",
-            "enText": "Where are you?",
+            "enText": "No, we're not!",
             "nextBlock": -1,
             "pathId": 105408599284019665,
             "blockIdx": 53

--- a/translations/story/82/0039/002 (勇戦ネバーギブアップ).json
+++ b/translations/story/82/0039/002 (勇戦ネバーギブアップ).json
@@ -9,7 +9,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "ゲームセンターの近くを通りかかると、\r\n対戦ゲームで遊ぶウオッカの姿が見えた。",
-            "enText": "As I walked past the arcade, \nI saw Vodka playing a game.",
+            "enText": "As I was passing by an arcade,\nI saw Vodka playing a fighting game.",
             "nextBlock": 2,
             "pathId": -7666063306190954876,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ゲームの音",
             "enName": "",
             "jpText": "（ダダダッ！　バゴォォーーーン！）\r\nKO！　1P、WIN！",
-            "enText": "(DADADADADAD! BAGOOOOM!) KO! 1P, WIN!",
+            "enText": "(Bam! Smash! Whack!)\nKO! Player 1 wins!",
             "nextBlock": 3,
             "pathId": 1489421183606988703,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "っし！　またまた連勝！",
-            "enText": "Yes! Another winning streak!",
+            "enText": "Alright! Another consecutive win!",
             "nextBlock": 4,
             "pathId": -823884485677729909,
             "blockIdx": 3
@@ -36,7 +36,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "くっ……。",
-            "enText": "Kudos to…",
+            "enText": "Ugh...",
             "nextBlock": 5,
             "pathId": -5972150592228420799,
             "blockIdx": 4
@@ -45,7 +45,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "よほど悔しいのか、対戦相手の小学生は\r\n唇をギュッと噛んでいる。",
-            "enText": "Her opponent, a schoolboy, was biting \nher lip in frustration.",
+            "enText": "Her opponent, a grade school boy,\nwas biting his lips out of frustration.",
             "nextBlock": 6,
             "pathId": -6031186246797154355,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "まー、これだけコテンパンにすりゃ\r\nさすがにあきらめんだろ――",
-            "enText": "Well, after all this beating, \nyou'd think they'd give up.",
+            "enText": "Welp, I guess he's finally given up\nafter being beaten up that much.",
             "nextBlock": 7,
             "pathId": 682567295695337688,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "ゲームの音",
             "enName": "",
             "jpText": "ニューチャレンジャーッ！！",
-            "enText": "New Challenger!",
+            "enText": "New challenger approaching!",
             "nextBlock": 8,
             "pathId": -4934511087496831294,
             "blockIdx": 7
@@ -72,7 +72,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "へえ……いい根性してるじゃねーか。",
-            "enText": "Heh… you've got good guts, don't you?",
+            "enText": "Ooh, he's got some guts.",
             "nextBlock": 9,
             "pathId": -9198254945549635712,
             "blockIdx": 8
@@ -81,7 +81,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……気に入ったぜ。\r\nクールにもてなしてやるよ……！",
-            "enText": "I like… I'll treat you cool…!",
+            "enText": "...I like that. Alright, I'll entertain you!",
             "nextBlock": 10,
             "pathId": 4119360550415338308,
             "blockIdx": 9
@@ -90,7 +90,7 @@
             "jpName": "ゲームの音",
             "enName": "",
             "jpText": "（ドガッ、バギッ、ドバァァーーン！）\r\nKO！　2P、WIN！",
-            "enText": "(Thud, thud, thud! ) KO! 2P, WIN!",
+            "enText": "(Wham! Pow! Kaboom!)\nKO! Player 2 wins!",
             "nextBlock": 11,
             "pathId": -8097178204846164108,
             "blockIdx": 10
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや～、やられたやられた！\r\nお前のあきらめないハートに完敗だよ！",
-            "enText": "Oh no, I'm beaten, I'm beaten! Your \nnever-give-up heart has defeated me!",
+            "enText": "Ah, man, I really lost!\nI completely surrender\nto your determination!",
             "nextBlock": 12,
             "pathId": -8475898665090047670,
             "blockIdx": 11
@@ -108,7 +108,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "もしかして……わざと負けたの？",
-            "enText": "Could it be that… lost on purpose?",
+            "enText": "... did you lose on purpose?",
             "nextBlock": 13,
             "pathId": 7832464923208211039,
             "blockIdx": 12
@@ -117,7 +117,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "えっ……わざとっつーか、\r\nお前のガッツを認めてだな……。",
-            "enText": "Well… on purpose, or in recognition \nof your guts…",
+            "enText": "I wouldn't say it was on purpose.\nIf anything it's more like...\nI acknowledged your guts.",
             "nextBlock": 14,
             "pathId": 476503405829270270,
             "blockIdx": 13
@@ -126,7 +126,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "うぅっ……バカにしないでよ！",
-            "enText": "Ugh… Don't make fun of me!",
+            "enText": "Ugh... don't make fun of me!",
             "nextBlock": 15,
             "pathId": 7535513655176610125,
             "blockIdx": 14
@@ -135,7 +135,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "（ダダダダダッ……！）",
-            "enText": "(da da da da da…!)",
+            "enText": "(Tap, tap, tap, tap ...)",
             "nextBlock": 16,
             "pathId": -8455797237486018877,
             "blockIdx": 15
@@ -144,7 +144,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あっ、おい！　どこ行くんだよ！",
-            "enText": "Oh, hey! Where are you going?",
+            "enText": "Ah, hey! Where are you going?",
             "nextBlock": 17,
             "pathId": 8195757580807584071,
             "blockIdx": 16
@@ -153,7 +153,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺はバカになんてしてねえ……。\r\nしてねえ……けど――",
-            "enText": "I ain't no fool… I ain't…",
+            "enText": "I'm not making fun of you.\nAt least I didn't mean to, but...",
             "nextBlock": 18,
             "pathId": -6712243321230742653,
             "blockIdx": 17
@@ -162,7 +162,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "くそっ……何やってんだよ、俺は……！",
-            "enText": "Damn… what are you doing, I'm…!",
+            "enText": "Damn it... just what am I doing!?",
             "nextBlock": 19,
             "pathId": 547502595993988182,
             "blockIdx": 18
@@ -171,7 +171,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どんだけボロ負けしたレースでも、\r\n勝ちを譲ってほしかったとは思わねえ。",
-            "enText": "I don't think I would have wanted \nher to win the race, no matter \nhow badly she was beaten.",
+            "enText": "No matter how badly I lost a race,\nI never once wanted the win\nto be handed over to me.",
             "nextBlock": 20,
             "pathId": -2313116556029098141,
             "blockIdx": 19
@@ -180,7 +180,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "負けた悔しさってのは、全力の\r\n相手に勝たなきゃずっと残ったまんまだ！",
-            "enText": "If you don't win against the best, you'll \nalways have the frustration of losing!",
+            "enText": "Because if I don't win against my\nopponent at full strength, the frustration\nof losing would never go away.",
             "nextBlock": 21,
             "pathId": 7082437325150612578,
             "blockIdx": 20
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "自分の実力で勝たなきゃ意味がねーんだよ！",
-            "enText": "If you don't win on your own \nmerits, what's the point!",
+            "enText": "There's no point to winning if\nit's not through your own strength!",
             "nextBlock": 22,
             "pathId": -7006823132375903689,
             "blockIdx": 21
@@ -198,7 +198,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いた！　見つけた！",
-            "enText": "There she is! I found her!",
+            "enText": "Oh, there he is! Found him!",
             "nextBlock": 23,
             "pathId": 1632831291472223281,
             "blockIdx": 22
@@ -207,7 +207,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "お、お姉ちゃん……？",
-            "enText": "Oh, sister…?",
+            "enText": "W-what? You're the girl\nfrom the arcade, right?",
             "nextBlock": 24,
             "pathId": -7053582998826444400,
             "blockIdx": 23
@@ -216,7 +216,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "さっきはホントに悪かった！　ごめん！",
-            "enText": "I'm so sorry about earlier! I'm sorry!",
+            "enText": "I'm really sorry for just now.\nI shouldn't have done that.",
             "nextBlock": 25,
             "pathId": -5232349852286021586,
             "blockIdx": 24
@@ -225,7 +225,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "お前の『勝ちたい』って気持ちを\r\n俺は……踏みにじるようなことしちまった！",
-            "enText": "I've done something to trample \non your… desire to win!",
+            "enText": "I... completely trampled\non your determination to win.",
             "nextBlock": 26,
             "pathId": 8993078952647407087,
             "blockIdx": 25
@@ -234,7 +234,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "……ううん。ボクの方こそ、\r\nしつこく挑んでごめん……。",
-            "enText": "… No. I'm sorry I've been so persistent \nin challenging you…",
+            "enText": "... It's okay. I'm sorry for\nbeing so persistent too.",
             "nextBlock": 27,
             "pathId": -6263745141042442491,
             "blockIdx": 26
@@ -243,7 +243,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なに言ってんだ！　何度でも挑んでくる\r\nお前は最高にカッコいいぜ！",
-            "enText": "What are you talking about? You're the \ncoolest thing I've ever seen!",
+            "enText": "What are you saying?!\nYou were seriously cool, not\ngiving up even after that many times!",
             "nextBlock": 28,
             "pathId": 579978252710493349,
             "blockIdx": 27
@@ -252,7 +252,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "お姉ちゃん……！",
-            "enText": "Sister…!",
+            "enText": "Really? You think so?",
             "nextBlock": 29,
             "pathId": -9069863326589722365,
             "blockIdx": 28
@@ -261,7 +261,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "ボク、もう1回お姉ちゃんと対戦したい！\r\n次こそ本気のお姉ちゃんを倒すから！",
-            "enText": "I want to play against you one more time! \nNext time I'll beat you for real!",
+            "enText": "...I really want to play against\nyou again! And this time,\nI'll win properly!",
             "nextBlock": 30,
             "pathId": 7778204945459121029,
             "blockIdx": 29
@@ -270,7 +270,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ああ！　『参りました』って\r\n言わせてやるから覚悟しろよ！",
-            "enText": "Aah! I'll make you say, \"Here I am!\"",
+            "enText": "Yeah! But I won't make it\neasy for you either, so get\nready to admit defeat!",
             "nextBlock": 31,
             "pathId": -4582741856356724031,
             "blockIdx": 30
@@ -279,7 +279,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "そっちこそ覚悟してね！",
-            "enText": "You're the one who should be prepared!",
+            "enText": "The same goes for you!",
             "nextBlock": 32,
             "pathId": 8831962924209605313,
             "blockIdx": 31
@@ -288,7 +288,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "言うじゃねーか！　へへっ！！",
-            "enText": "You're so right! Heh!",
+            "enText": "Heh, now you've said it!\nThat's how it should be!",
             "nextBlock": -1,
             "pathId": -2059800877109396979,
             "blockIdx": 32

--- a/translations/story/82/0039/002 (勇戦ネバーギブアップ).json
+++ b/translations/story/82/0039/002 (勇戦ネバーギブアップ).json
@@ -9,7 +9,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "ゲームセンターの近くを通りかかると、\r\n対戦ゲームで遊ぶウオッカの姿が見えた。",
-            "enText": "As I was passing by an arcade,\nI saw Vodka playing a fighting game.",
+            "enText": "As I was passing by an arcade, I saw Vodka\nplaying a fighting game.",
             "nextBlock": 2,
             "pathId": -7666063306190954876,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ゲームの音",
             "enName": "",
             "jpText": "（ダダダッ！　バゴォォーーーン！）\r\nKO！　1P、WIN！",
-            "enText": "(Bam! Smash! Whack!)\nKO! Player 1 wins!",
+            "enText": "(Bam! Smash! Whack!) KO! Player 1 wins!",
             "nextBlock": 3,
             "pathId": 1489421183606988703,
             "blockIdx": 2
@@ -45,7 +45,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "よほど悔しいのか、対戦相手の小学生は\r\n唇をギュッと噛んでいる。",
-            "enText": "Her opponent, a grade school boy,\nwas biting his lips out of frustration.",
+            "enText": "Her opponent, a grade school boy, was biting\nhis lips out of frustration.",
             "nextBlock": 6,
             "pathId": -6031186246797154355,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "まー、これだけコテンパンにすりゃ\r\nさすがにあきらめんだろ――",
-            "enText": "Welp, I guess he's finally given up\nafter being beaten up that much.",
+            "enText": "Welp, I guess he's finally given up after\nbeing beaten up that much.",
             "nextBlock": 7,
             "pathId": 682567295695337688,
             "blockIdx": 6
@@ -90,7 +90,7 @@
             "jpName": "ゲームの音",
             "enName": "",
             "jpText": "（ドガッ、バギッ、ドバァァーーン！）\r\nKO！　2P、WIN！",
-            "enText": "(Wham! Pow! Kaboom!)\nKO! Player 2 wins!",
+            "enText": "(Wham! Pow! Kaboom!) KO! Player 2 wins!",
             "nextBlock": 11,
             "pathId": -8097178204846164108,
             "blockIdx": 10
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや～、やられたやられた！\r\nお前のあきらめないハートに完敗だよ！",
-            "enText": "Ah, man, I really lost!\nI completely surrender\nto your determination!",
+            "enText": "Ah, man, I really lost! I completely\nsurrender to your determination!",
             "nextBlock": 12,
             "pathId": -8475898665090047670,
             "blockIdx": 11
@@ -117,7 +117,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "えっ……わざとっつーか、\r\nお前のガッツを認めてだな……。",
-            "enText": "I wouldn't say it was on purpose.\nIf anything it's more like...\nI acknowledged your guts.",
+            "enText": "I wouldn't say it was on purpose. If anything\nit's more like... I acknowledged your guts.",
             "nextBlock": 14,
             "pathId": 476503405829270270,
             "blockIdx": 13
@@ -153,7 +153,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺はバカになんてしてねえ……。\r\nしてねえ……けど――",
-            "enText": "I'm not making fun of you.\nAt least I didn't mean to, but...",
+            "enText": "I'm not making fun of you. At least\nI didn't mean to, but...",
             "nextBlock": 18,
             "pathId": -6712243321230742653,
             "blockIdx": 17
@@ -171,7 +171,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どんだけボロ負けしたレースでも、\r\n勝ちを譲ってほしかったとは思わねえ。",
-            "enText": "No matter how badly I lost a race,\nI never once wanted the win\nto be handed over to me.",
+            "enText": "No matter how badly I lost a race, I never\nonce wanted the win to be handed over to me.",
             "nextBlock": 20,
             "pathId": -2313116556029098141,
             "blockIdx": 19
@@ -180,7 +180,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "負けた悔しさってのは、全力の\r\n相手に勝たなきゃずっと残ったまんまだ！",
-            "enText": "Because if I don't win against my\nopponent at full strength, the frustration\nof losing would never go away.",
+            "enText": "Because if I don't win against my opponent at\nfull strength, the frustration of losing\nwould never go away.",
             "nextBlock": 21,
             "pathId": 7082437325150612578,
             "blockIdx": 20
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "自分の実力で勝たなきゃ意味がねーんだよ！",
-            "enText": "There's no point to winning if\nit's not through your own strength!",
+            "enText": "There's no point to winning if it's not\nthrough your own strength!",
             "nextBlock": 22,
             "pathId": -7006823132375903689,
             "blockIdx": 21
@@ -207,7 +207,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "お、お姉ちゃん……？",
-            "enText": "W-what? You're the girl\nfrom the arcade, right?",
+            "enText": "W-what? You're the girl from\nthe arcade, right?",
             "nextBlock": 24,
             "pathId": -7053582998826444400,
             "blockIdx": 23
@@ -225,7 +225,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "お前の『勝ちたい』って気持ちを\r\n俺は……踏みにじるようなことしちまった！",
-            "enText": "I... completely trampled\non your determination to win.",
+            "enText": "I... completely trampled on\nyour determination to win.",
             "nextBlock": 26,
             "pathId": 8993078952647407087,
             "blockIdx": 25
@@ -243,7 +243,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なに言ってんだ！　何度でも挑んでくる\r\nお前は最高にカッコいいぜ！",
-            "enText": "What are you saying?!\nYou were seriously cool, not\ngiving up even after that many times!",
+            "enText": "What are you saying?! You were\nseriously cool, not giving up even\nafter that many times!",
             "nextBlock": 28,
             "pathId": 579978252710493349,
             "blockIdx": 27
@@ -261,7 +261,7 @@
             "jpName": "男子小学生",
             "enName": "",
             "jpText": "ボク、もう1回お姉ちゃんと対戦したい！\r\n次こそ本気のお姉ちゃんを倒すから！",
-            "enText": "...I really want to play against\nyou again! And this time,\nI'll win properly!",
+            "enText": "...I really want to play against you again!\nAnd this time, I'll win properly!",
             "nextBlock": 30,
             "pathId": 7778204945459121029,
             "blockIdx": 29
@@ -270,7 +270,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ああ！　『参りました』って\r\n言わせてやるから覚悟しろよ！",
-            "enText": "Yeah! But I won't make it\neasy for you either, so get\nready to admit defeat!",
+            "enText": "Yeah! But I won't make it easy for you\neither, so get ready to admit defeat!",
             "nextBlock": 31,
             "pathId": -4582741856356724031,
             "blockIdx": 30
@@ -288,7 +288,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "言うじゃねーか！　へへっ！！",
-            "enText": "Heh, now you've said it!\nThat's how it should be!",
+            "enText": "Heh, now you've said it! That's\nhow it should be!",
             "nextBlock": -1,
             "pathId": -2059800877109396979,
             "blockIdx": 32


### PR DESCRIPTION
This PR adds proper translation for the training events of the "Annoying Observer" (SR) Vodka support card. I've also updated the tl-progress file to account for my previous as well as this PR.

I again don't know whether this linebreaking actually fits ingame as I do not use the patch, all I did was run textprocess (with `-nl` and `-rep none`) over it.