### PR TITLE
Add Vodka SSR support card events

### DIFF
--- a/tl-progress.md
+++ b/tl-progress.md
@@ -90,6 +90,7 @@ name | progress | translator
 All except the below (up to 30/12/2021) | Complete | deepl
 Vodka (R, Tracen Academy) | Complete | [robflop][]
 Vodka (SR, Annoying Observer) | Complete | [robflop][]
+Vodka (SSR, Road of Vodka) | Complete | [robflop][]
 
 # Home Dialogue
 name | progress | translator

--- a/translations/story/80/1008/001 (憧れのセリフ).json
+++ b/translations/story/80/1008/001 (憧れのセリフ).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある日、トレーナー室へ向かっていると――",
-            "enText": "One day, on the way to the\ntrainer's office...",
+            "enText": "One day, on the way\nto the trainer's office...",
             "nextBlock": 2,
             "pathId": 6568414105838612420,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！！』",
-            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\" \"Come,\nI'll kick your ass.\"",
+            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\"\n\"Come, I'll kick your ass.\"",
             "nextBlock": 3,
             "pathId": -2751798553862275875,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なんっかちげーな。もーちっとこう……\r\n……『ブチカマすぜぇぇ！！』",
-            "enText": "Hmm, that feels off. It should be more\nlike... \"I'm gonna kick your ass!\"",
+            "enText": "Hmm, that feels off. It should be\nmore like... \"I'm gonna kick your ass!\"",
             "nextBlock": 4,
             "choices": [
                 {
@@ -43,7 +43,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "――ハッ！\r\nアアアアンタ、いつの間に……！",
-            "enText": "--Woah! S-since when have you been here?",
+            "enText": "--Woah!\nS-since when have you been here?",
             "nextBlock": 5,
             "pathId": 5605984693871499806,
             "blockIdx": 4
@@ -52,7 +52,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "つーか、まてまて誰にも言うなよ！？\r\nカッコつけの練習見られるとかダセェだろ！？",
-            "enText": "I mean, don't tell anyone about this! Being\nseen practicing cool phrases would be\nseriously lame.",
+            "enText": "I mean, don't tell anyone about this!\nBeing seen practicing cool phrases\nwould be seriously lame.",
             "nextBlock": 6,
             "pathId": -4716578934516563664,
             "blockIdx": 5
@@ -61,7 +61,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "それに、本当はもっとカッケェんだ。\r\n今のは全然仕上がってねーの！",
-            "enText": "The real deal's much cooler too. I haven't\nmanaged to get it down at all yet.",
+            "enText": "The real deal's much cooler too.\nI haven't managed to get it down\nat all yet.",
             "nextBlock": 7,
             "choices": [
                 {
@@ -91,7 +91,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！』\r\nってなぁ！　くぅ～～～、カッケェ～～ッ！",
-            "enText": "So he's like \"I'm gonna kick your ass!\" Man,\nhe's seriously so cool!",
+            "enText": "So he's like \"I'm gonna kick your ass!\"\nMan, he's seriously so cool!",
             "nextBlock": 9,
             "pathId": -4401138221719148632,
             "blockIdx": 8
@@ -121,7 +121,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "見た目を……！　その手があったか！\r\n確かに、あの漫画のヤツら超ムキムキだぜ！",
-            "enText": "Oh, I didn't consider looking wild yet.\nThinking of it, everyone in the manga is\nreally muscular too!",
+            "enText": "Oh, I didn't consider looking wild yet.\nThinking of it, everyone in the\nmanga is really muscular too!",
             "nextBlock": 11,
             "pathId": -1067756012550727100,
             "blockIdx": 10
@@ -130,7 +130,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ムキムキになりゃ、ムキムキの見てる世界が\r\nわかるかもしんねぇ！",
-            "enText": "If I become really muscular too,\nmaybe I'll understand the way buff\npeople see the world better!",
+            "enText": "If I become really muscular too,\nmaybe I'll understand the way\nbuff people see the world better!",
             "nextBlock": 12,
             "pathId": -7760042973725619736,
             "blockIdx": 11
@@ -148,7 +148,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "その後、ウオッカがジムにて、かなり熱心に\r\n筋トレをしていたという噂を聞いた。",
-            "enText": "After that, I heard about how Vodka\nfeverously trained at the gym.",
+            "enText": "After that, I heard about how\nVodka feverously trained at the gym.",
             "nextBlock": -1,
             "pathId": 4728923334065708207,
             "blockIdx": 13
@@ -157,7 +157,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ワイルドなポーズか……。\r\n確かに、カッケェポーズでキめてたな……。",
-            "enText": "Striking a cool pose, huh... Yeah,\nI think that could work.",
+            "enText": "Striking a cool pose, huh...\nYeah, I think that could work.",
             "nextBlock": 15,
             "pathId": -5901416184483430351,
             "blockIdx": 14
@@ -175,7 +175,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スッゲーテンション上がってきたぜ……！\r\nちょっと鏡取ってくる！　サンキューな！",
-            "enText": "Alright, now I'm pumped! Time to go check\nthis out in a mirror! Thanks!",
+            "enText": "Alright, now I'm pumped! Time to go\ncheck this out in a mirror! Thanks!",
             "nextBlock": 17,
             "pathId": -8243106386738906873,
             "blockIdx": 16
@@ -184,7 +184,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ウオッカのポーズの研究は、\r\n夜が更けるまで熱心に行われたようだった。",
-            "enText": "And so, Vodka enthusiastically practiced\nposing late into the night.",
+            "enText": "And so, Vodka enthusiastically\npracticed posing late into the night.",
             "nextBlock": -1,
             "pathId": 3346411762792462372,
             "blockIdx": 17

--- a/translations/story/80/1008/001 (憧れのセリフ).json
+++ b/translations/story/80/1008/001 (憧れのセリフ).json
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "『天上天下唯我独尊……ブチカマすぜぇ！！』",
-            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\"\n\"Come, I'll kick your ass.\"",
+            "enText": "\"Throughout the heavens and earth,\nI alone am the honored one...\nCome, I'll kick your ass.\"",
             "nextBlock": 3,
             "pathId": -2751798553862275875,
             "blockIdx": 2

--- a/translations/story/80/1008/002 (大通りの強敵).json
+++ b/translations/story/80/1008/002 (大通りの強敵).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある休日、出かける途中に\r\n校門前を通りかかると――",
-            "enText": "On a day off, while I was walking\npast the school gate...",
+            "enText": "On a day off, while I was\nwalking past the school gate...",
             "nextBlock": 2,
             "pathId": -8270600719711619383,
             "blockIdx": 1
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "チ、チクショー……早くいかねーと\r\nバイク写真集売り切れちまうってのに……！",
-            "enText": "Damn it...if I don't hurry up, they'll sell\nout of bike photo books!",
+            "enText": "Damn it...if I don't hurry up,\nthey'll sell out of bike photo books!",
             "nextBlock": 7,
             "pathId": 6026270507745678907,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なあ、アンタ！　大通りの軟派なヤツら\r\n避ける方法、なんか知らねーか！？",
-            "enText": "Hey, you! Do you have any idea how\nto avoid running into guys trying\nto pick up girls in public?",
+            "enText": "Hey, you! Do you have any idea\nhow to avoid running into guys\ntrying to pick up girls in public?",
             "nextBlock": 8,
             "choices": [
                 {
@@ -84,7 +84,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "脇道……！　そうだ、\r\nほかに道があること忘れてた！",
-            "enText": "A side street? You're right, I totally forgot\nI could just take another way!",
+            "enText": "A side street? You're right, I totally\nforgot I could just take another way!",
             "nextBlock": 9,
             "pathId": -4059325463002486051,
             "blockIdx": 8
@@ -111,7 +111,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……一応言っとっけど、別にキ……が\r\n怖ぇわけじゃねーぞ！　勘違いすんなよ！",
-            "enText": "Just so you know though, it's not\nlike I'm scared of ki-.. being hit\non! Don't misunderstand!",
+            "enText": "Just so you know though, it's not\nlike I'm scared of ki-.. being hit on!\nDon't misunderstand!",
             "nextBlock": -1,
             "pathId": -675035334323726827,
             "blockIdx": 11
@@ -120,7 +120,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "全力疾走……！\r\n見ちまう前に、走り抜けろってことか！？",
-            "enText": "Running as fast as I can... So that they\ndon't even get a chance to approach me?",
+            "enText": "Running as fast as I can...\nSo that they don't even get\na chance to approach me?",
             "nextBlock": 13,
             "pathId": 4914256322229187976,
             "blockIdx": 12
@@ -129,7 +129,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや、俺ならやれる！　やってやらぁ！\r\n光より速く駆けりゃいい話だ！",
-            "enText": "Yeah, I'm sure I can do that! I'll dash by\nthem faster than the speed of light!",
+            "enText": "Yeah, I'm sure I can do that!\nI'll dash by them faster than\nthe speed of light!",
             "nextBlock": 14,
             "pathId": 8596648460312197017,
             "blockIdx": 13
@@ -138,7 +138,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よっしゃ、そうと決まりゃ怖いモンなしだぜ！\r\nサンキューな！！",
-            "enText": "Alright, I've got nothing to be afraid\nof if I do that! Thanks!",
+            "enText": "Alright, I've got nothing to be\nafraid of if I do that! Thanks!",
             "nextBlock": 15,
             "pathId": 8600605470322004766,
             "blockIdx": 14
@@ -147,7 +147,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……違う、怖ぇんじゃねぇ、軟派なモンが\r\n嫌いなだけだ！　勘違いすんなよ！",
-            "enText": "... I mean, not like I'm scared! I just\ndislike getting hit on, don't misunderstand!",
+            "enText": "... I mean, not like I'm scared!\nI just dislike getting hit on,\ndon't misunderstand!",
             "nextBlock": -1,
             "pathId": -2539076437391671355,
             "blockIdx": 15

--- a/translations/story/82/0039/001 (黄昏サボタージュ).json
+++ b/translations/story/82/0039/001 (黄昏サボタージュ).json
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あー、うっせーな！\r\n集中して見られねーだろ！",
-            "enText": "Ugh, leave me alone! I can't\nfocus on watching!",
+            "enText": "Ugh, leave me alone!\nI can't focus on watching!",
             "nextBlock": 3,
             "pathId": -1032555894439955970,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "今は掃除の時間でしょっ！\r\nバイクレースなんて録画でもしときなさいよ！",
-            "enText": "We're on cleaning duty right now! Just watch\na recording of that bike race!",
+            "enText": "We're on cleaning duty right now!\nJust watch a recording\nof that bike race!",
             "nextBlock": 4,
             "pathId": 755144075983670730,
             "blockIdx": 3
@@ -45,7 +45,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "な～にがロマンよ！　偉そうなこと言うのは\r\nやることやってからにしなさい！",
-            "enText": "What's there to understand? You can talk like\nthat after you're done with what you're\nsupposed to be doing!",
+            "enText": "What's there to understand?\nYou can talk like that after you're done\nwith what you're supposed to be doing!",
             "nextBlock": 6,
             "pathId": 7618667823475009207,
             "blockIdx": 5
@@ -63,7 +63,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "掃除はやりたいヤツがやりゃいいだろ！",
-            "enText": "Do your cleaning alone if you\nwanna do it that much!",
+            "enText": "Do your cleaning alone\nif you wanna do it that much!",
             "nextBlock": 8,
             "pathId": 5162077456848096475,
             "blockIdx": 7
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あぁー、くそ！　なんだってんだ……！\r\nこんなはずじゃ……あぁぁー、もう！",
-            "enText": "Damn it...! Why do I feel like this? This\nisn't how it was supposed to be...!",
+            "enText": "Damn it...! Why do I feel like this?\nThis isn't how it was supposed to be...!",
             "nextBlock": 12,
             "choices": [
                 {
@@ -138,7 +138,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "な～にがロマンよ！　偉そうなこと言うのは\r\nやることやってからにしなさい！",
-            "enText": "What's there to understand? You can talk like\nthat after you're done with what you're\nsupposed to be doing!",
+            "enText": "What's there to understand?\nYou can talk like that after you're done\nwith what you're supposed to be doing!",
             "nextBlock": 15,
             "pathId": -6309102875795735290,
             "blockIdx": 14
@@ -147,7 +147,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "アイツの言う通りだ……。\r\nやらなきゃならねーこと投げ出すなんて――",
-            "enText": "...She's completely right. Ditching\nthings you should do...",
+            "enText": "...She's completely right.\nDitching things you should do...",
             "nextBlock": 16,
             "pathId": -3088162865032064386,
             "blockIdx": 15
@@ -156,7 +156,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ハンパすぎんだろ……！\r\nダサすぎんだろ……ちくしょー！",
-            "enText": "It's way too half-assed! I'm\nseriously lame... damn it!",
+            "enText": "It's way too half-assed!\nI'm seriously lame... damn it!",
             "nextBlock": 17,
             "pathId": 3481697921921330977,
             "blockIdx": 16
@@ -186,7 +186,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "…………だな。\r\nそれしかねーよな！",
-            "enText": "... Yeah, you're right. That's\nwhat I should do.",
+            "enText": "... Yeah, you're right.\nThat's what I should do.",
             "nextBlock": 19,
             "pathId": 8876938363864511224,
             "blockIdx": 18
@@ -195,7 +195,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "反省してるっ！　アイツにも悪ぃことした！\r\n2度とこんなダセー真似はしねえっ！",
-            "enText": "I'm gonna make it up to her for sure! And\nI'll never be this lame again, either.",
+            "enText": "I'm gonna make it up to her for sure!\nAnd I'll never be this lame again, either.",
             "nextBlock": 20,
             "pathId": -3227448119379770002,
             "blockIdx": 19
@@ -204,7 +204,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "と、そこへ――",
-            "enText": "Right when we were about to\nreturn to the classroom--",
+            "enText": "Right when we were about\nto return to the classroom--",
             "nextBlock": 21,
             "pathId": 6625004654339446017,
             "blockIdx": 20
@@ -213,7 +213,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はいはい、どいてどいて。\r\nゴミ捨ての邪魔だから。",
-            "enText": "Yeah, yeah. Move it, you're in the\nway of the trash container.",
+            "enText": "Yeah, yeah. Move it, you're in\nthe way of the trash container.",
             "nextBlock": 22,
             "pathId": 1047714431026897678,
             "blockIdx": 21
@@ -222,7 +222,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スカーレット！\r\nい、今の聞いてたのかよ！？",
-            "enText": "Scarlet! D-did you hear what I just said?",
+            "enText": "Scarlet!\nD-did you hear what I just said?",
             "nextBlock": 23,
             "pathId": -5068198949885098693,
             "blockIdx": 22
@@ -258,7 +258,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "はいはい。……で、アイツって誰なのよ？",
-            "enText": "Yeah, yeah. ...So, who's this someone?",
+            "enText": "Yeah, yeah.\n...So, who's this someone?",
             "nextBlock": 27,
             "pathId": 3665815265002429655,
             "blockIdx": 26
@@ -267,7 +267,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "そ、その話はもういーじゃねーか！\r\nアイツはアイツだよ！",
-            "enText": "Enough of that already! Someone's someone!",
+            "enText": "Enough of that already!\nSomeone's someone!",
             "nextBlock": 28,
             "pathId": -6226635499037709515,
             "blockIdx": 27
@@ -303,7 +303,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺は逃げねえ！　ビシッと謝ってやる！",
-            "enText": "I'm not gonna run away! I'm gonna\nproperly apologize to her!",
+            "enText": "I'm not gonna run away!\nI'm gonna properly apologize to her!",
             "nextBlock": 32,
             "pathId": -8249517779102871705,
             "blockIdx": 31
@@ -312,7 +312,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "と、そこへ――",
-            "enText": "Right when we were about to\nreturn to the classroom--",
+            "enText": "Right when we were about\nto return to the classroom--",
             "nextBlock": 33,
             "pathId": -1445520822394854448,
             "blockIdx": 32
@@ -321,7 +321,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "アンタ、こんなとこにいたの？\r\nで、誰がなにを謝るって？",
-            "enText": "So this is where you've been? And what's this\nabout someone apologizing for something?",
+            "enText": "So this is where you've been?\nAnd what's this about someone\napologizing for something?",
             "nextBlock": 34,
             "pathId": 2441965058879445788,
             "blockIdx": 33
@@ -330,7 +330,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スカーレット！　ちょうどよかった！\r\nあ、あのよ……！",
-            "enText": "Scarlet! Perfect timing. U-um, so...!",
+            "enText": "Scarlet! Perfect timing.\nU-um, so...!",
             "nextBlock": 35,
             "pathId": 4111051617905567172,
             "blockIdx": 34
@@ -339,7 +339,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "掃除サボって悪かった……！\r\n自分のこと考えてばっかで、その……。",
-            "enText": "I'm sorry for ditching cleaning duty. Only\nthinking about myself like that...",
+            "enText": "I'm sorry for ditching cleaning duty.\nOnly thinking about myself like that...",
             "nextBlock": 36,
             "pathId": -413747710141347246,
             "blockIdx": 35
@@ -357,7 +357,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "当たり前だろ！　腰抜かすくらい\r\nキレイにしてやるよ！",
-            "enText": "Of course! When I'm done, the classroom will\nbe clean enough to blind you!",
+            "enText": "Of course! When I'm done, the\nclassroom will be clean\nenough to blind you!",
             "nextBlock": 38,
             "pathId": 3937740679662264900,
             "blockIdx": 37
@@ -366,7 +366,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "よーし、やるぞー！\r\nオマエは拭き掃除、俺が掃き掃除な。",
-            "enText": "Alright, let's do this! You wipe the room,\nand I'll sweep the floor!",
+            "enText": "Alright, let's do this!\nYou wipe the room,\nand I'll sweep the floor!",
             "nextBlock": 39,
             "pathId": 5889443046115172597,
             "blockIdx": 38
@@ -375,7 +375,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "さっきまでサボってたヤツが偉そうに……。",
-            "enText": "For someone that was just slacking off, you\nsure are taking charge now...",
+            "enText": "For someone that was just slacking\noff, you sure are taking charge now...",
             "nextBlock": 40,
             "pathId": -2552116722999487482,
             "blockIdx": 39
@@ -384,7 +384,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "あれ、そういえばバイクレースの\r\n中継は終わったの？",
-            "enText": "Oh, right. What about that bike\nrace? Is that already over?",
+            "enText": "Oh, right. What about that bike race?\nIs that already over?",
             "nextBlock": 41,
             "pathId": 3126675204085017802,
             "blockIdx": 40
@@ -393,7 +393,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや、まだやってるぜ。\r\nでも今はそれどころじゃねーからな。",
-            "enText": "No, it's still going on. But that's\nnot important right now.",
+            "enText": "No, it's still going on.\nBut that's not important right now.",
             "nextBlock": 42,
             "pathId": 1458447945309386426,
             "blockIdx": 41
@@ -402,7 +402,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "へえ……やけに真面目じゃない。\r\nなんか悪いものでも食べたわけ？",
-            "enText": "Huh, you sure are being obedient\nnow. Did you eat something bad?",
+            "enText": "Huh, you sure are being obedient now.\nDid you eat something bad?",
             "nextBlock": 43,
             "pathId": -4469646238871257671,
             "blockIdx": 42
@@ -420,7 +420,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ハンパなままじゃ、カッコいいもんに\r\n憧れる資格がねーからな！",
-            "enText": "I can't be cool if I do things in a\nhalf-assed way, after all!",
+            "enText": "I can't be cool if I do things\nin a half-assed way, after all!",
             "nextBlock": 45,
             "pathId": 842931133127544634,
             "blockIdx": 44

--- a/translations/story/82/0039/002 (勇戦ネバーギブアップ).json
+++ b/translations/story/82/0039/002 (勇戦ネバーギブアップ).json
@@ -9,16 +9,16 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "ゲームセンターの近くを通りかかると、\r\n対戦ゲームで遊ぶウオッカの姿が見えた。",
-            "enText": "As I was passing by an arcade, I saw Vodka\nplaying a fighting game.",
+            "enText": "As I was passing by an arcade,\nI saw Vodka playing a fighting game.",
             "nextBlock": 2,
             "pathId": -7666063306190954876,
             "blockIdx": 1
         },
         {
             "jpName": "ゲームの音",
-            "enName": "",
+            "enName": "arcade game",
             "jpText": "（ダダダッ！　バゴォォーーーン！）\r\nKO！　1P、WIN！",
-            "enText": "(Bam! Smash! Whack!) KO! Player 1 wins!",
+            "enText": "(Bam! Smash! Whack!)\nKO! Player 1 wins!",
             "nextBlock": 3,
             "pathId": 1489421183606988703,
             "blockIdx": 2
@@ -34,7 +34,7 @@
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "くっ……。",
             "enText": "Ugh...",
             "nextBlock": 5,
@@ -45,7 +45,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "よほど悔しいのか、対戦相手の小学生は\r\n唇をギュッと噛んでいる。",
-            "enText": "Her opponent, a grade school boy, was biting\nhis lips out of frustration.",
+            "enText": "Her opponent, a grade school boy,\nwas biting his lips out of frustration.",
             "nextBlock": 6,
             "pathId": -6031186246797154355,
             "blockIdx": 5
@@ -54,14 +54,14 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "まー、これだけコテンパンにすりゃ\r\nさすがにあきらめんだろ――",
-            "enText": "Welp, I guess he's finally given up after\nbeing beaten up that much.",
+            "enText": "Welp, I guess he's finally given up\nafter being beaten up that much.",
             "nextBlock": 7,
             "pathId": 682567295695337688,
             "blockIdx": 6
         },
         {
             "jpName": "ゲームの音",
-            "enName": "",
+            "enName": "arcade game",
             "jpText": "ニューチャレンジャーッ！！",
             "enText": "New challenger approaching!",
             "nextBlock": 8,
@@ -88,9 +88,9 @@
         },
         {
             "jpName": "ゲームの音",
-            "enName": "",
+            "enName": "arcade game",
             "jpText": "（ドガッ、バギッ、ドバァァーーン！）\r\nKO！　2P、WIN！",
-            "enText": "(Wham! Pow! Kaboom!) KO! Player 2 wins!",
+            "enText": "(Wham! Pow! Kaboom!)\nKO! Player 2 wins!",
             "nextBlock": 11,
             "pathId": -8097178204846164108,
             "blockIdx": 10
@@ -99,14 +99,14 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いや～、やられたやられた！\r\nお前のあきらめないハートに完敗だよ！",
-            "enText": "Ah, man, I really lost! I completely\nsurrender to your determination!",
+            "enText": "Ah, man, I really lost!\nI completely surrender\nto your determination!",
             "nextBlock": 12,
             "pathId": -8475898665090047670,
             "blockIdx": 11
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "もしかして……わざと負けたの？",
             "enText": "... did you lose on purpose?",
             "nextBlock": 13,
@@ -117,14 +117,14 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "えっ……わざとっつーか、\r\nお前のガッツを認めてだな……。",
-            "enText": "I wouldn't say it was on purpose. If anything\nit's more like... I acknowledged your guts.",
+            "enText": "I wouldn't say it was on purpose.\nIf anything it's more like...\nI acknowledged your guts.",
             "nextBlock": 14,
             "pathId": 476503405829270270,
             "blockIdx": 13
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "うぅっ……バカにしないでよ！",
             "enText": "Ugh... don't make fun of me!",
             "nextBlock": 15,
@@ -153,7 +153,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺はバカになんてしてねえ……。\r\nしてねえ……けど――",
-            "enText": "I'm not making fun of you. At least\nI didn't mean to, but...",
+            "enText": "I'm not making fun of you.\nAt least I didn't mean to, but...",
             "nextBlock": 18,
             "pathId": -6712243321230742653,
             "blockIdx": 17
@@ -171,7 +171,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どんだけボロ負けしたレースでも、\r\n勝ちを譲ってほしかったとは思わねえ。",
-            "enText": "No matter how badly I lost a race, I never\nonce wanted the win to be handed over to me.",
+            "enText": "No matter how badly I lost a race,\nI never once wanted the win\nto be handed over to me.",
             "nextBlock": 20,
             "pathId": -2313116556029098141,
             "blockIdx": 19
@@ -180,7 +180,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "負けた悔しさってのは、全力の\r\n相手に勝たなきゃずっと残ったまんまだ！",
-            "enText": "Because if I don't win against my opponent at\nfull strength, the frustration of losing\nwould never go away.",
+            "enText": "Because if I don't win against my\nopponent at full strength, the frustration\nof losing would never go away.",
             "nextBlock": 21,
             "pathId": 7082437325150612578,
             "blockIdx": 20
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "自分の実力で勝たなきゃ意味がねーんだよ！",
-            "enText": "There's no point to winning if it's not\nthrough your own strength!",
+            "enText": "There's no point to winning if\nit's not through your own strength!",
             "nextBlock": 22,
             "pathId": -7006823132375903689,
             "blockIdx": 21
@@ -205,9 +205,9 @@
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "お、お姉ちゃん……？",
-            "enText": "W-what? You're the girl from\nthe arcade, right?",
+            "enText": "W-what? You're the girl\nfrom the arcade, right?",
             "nextBlock": 24,
             "pathId": -7053582998826444400,
             "blockIdx": 23
@@ -225,14 +225,14 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "お前の『勝ちたい』って気持ちを\r\n俺は……踏みにじるようなことしちまった！",
-            "enText": "I... completely trampled on\nyour determination to win.",
+            "enText": "I... completely trampled\non your determination to win.",
             "nextBlock": 26,
             "pathId": 8993078952647407087,
             "blockIdx": 25
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "……ううん。ボクの方こそ、\r\nしつこく挑んでごめん……。",
             "enText": "... It's okay. I'm sorry for\nbeing so persistent too.",
             "nextBlock": 27,
@@ -243,14 +243,14 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "なに言ってんだ！　何度でも挑んでくる\r\nお前は最高にカッコいいぜ！",
-            "enText": "What are you saying?! You were\nseriously cool, not giving up even\nafter that many times!",
+            "enText": "What are you saying?!\nYou were seriously cool, not\ngiving up even after that many times!",
             "nextBlock": 28,
             "pathId": 579978252710493349,
             "blockIdx": 27
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "お姉ちゃん……！",
             "enText": "Really? You think so?",
             "nextBlock": 29,
@@ -259,9 +259,9 @@
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "ボク、もう1回お姉ちゃんと対戦したい！\r\n次こそ本気のお姉ちゃんを倒すから！",
-            "enText": "...I really want to play against you again!\nAnd this time, I'll win properly!",
+            "enText": "...I really want to play against\nyou again! And this time,\nI'll win properly!",
             "nextBlock": 30,
             "pathId": 7778204945459121029,
             "blockIdx": 29
@@ -270,14 +270,14 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ああ！　『参りました』って\r\n言わせてやるから覚悟しろよ！",
-            "enText": "Yeah! But I won't make it easy for you\neither, so get ready to admit defeat!",
+            "enText": "Yeah! But I won't make it\neasy for you either, so get\nready to admit defeat!",
             "nextBlock": 31,
             "pathId": -4582741856356724031,
             "blockIdx": 30
         },
         {
             "jpName": "男子小学生",
-            "enName": "",
+            "enName": "gradeschooler",
             "jpText": "そっちこそ覚悟してね！",
             "enText": "The same goes for you!",
             "nextBlock": 32,
@@ -288,7 +288,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "言うじゃねーか！　へへっ！！",
-            "enText": "Heh, now you've said it! That's\nhow it should be!",
+            "enText": "Heh, now you've said it!\nThat's how it should be!",
             "nextBlock": -1,
             "pathId": -2059800877109396979,
             "blockIdx": 32

--- a/translations/story/83/0005/001 (従うのは、自分の心).json
+++ b/translations/story/83/0005/001 (従うのは、自分の心).json
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……けど、一緒にやるって言っちまったしな。\r\nダセェことはなしだ、挑戦しに行ったらぁ！",
-            "enText": "... no, that doesn't matter! I've decided\nthat I'd help you out, so I'll see it through!\nNot doing so would be super lame!",
+            "enText": "... no, that doesn't matter! I've decided\nthat I'd help you out, so I'll see it\nthrough! Not doing so would be super lame!",
             "nextBlock": 22,
             "pathId": -2101802772233131709,
             "blockIdx": 21

--- a/translations/story/83/0005/001 (従うのは、自分の心).json
+++ b/translations/story/83/0005/001 (従うのは、自分の心).json
@@ -9,7 +9,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "夕方、トレーニングコースに顔を出すと――",
-            "enText": "In the evening, I showed up \nat the training course.",
+            "enText": "I was checking out the training\ncourse during evening, when...",
             "nextBlock": 2,
             "pathId": 2006608558334823483,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "おつかれっすー！\r\nスぺ先輩、ナイス併走っした！",
-            "enText": "Good night! Nice ride with you, Supe!",
+            "enText": "Good training today, Spe!\nThat was some nice running.",
             "nextBlock": 3,
             "pathId": 1309343546476663515,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "…………。",
-            "enText": "…",
+            "enText": "...........",
             "nextBlock": 4,
             "pathId": -8641803145931653206,
             "blockIdx": 3
@@ -36,7 +36,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "スぺ先輩？　スペせーんーぱーいー？",
-            "enText": "Supe senpai? Spesenpai?",
+            "enText": "Spe? Hello, Earth to Special Week?",
             "nextBlock": 5,
             "pathId": 5023491764095107703,
             "blockIdx": 4
@@ -45,7 +45,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "ひゃわっ！？　す、すみませんっ！\r\n北海道のジャガイモは甘くて美味しいですよ！",
-            "enText": "What? I'm sorry! Hokkaido's potatoes \nare sweet and delicious!",
+            "enText": "Waah! I'm sorry!\nPotatoes from Hokkaido\nare very sweet and delicious!",
             "nextBlock": 6,
             "pathId": -7841977810709256490,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……んな話、してないっす。\r\nはぁ……先輩、ちょっとこっちこっち。",
-            "enText": "I'm not talking about… I'm not talking \nabout… you, I'm talking about you.",
+            "enText": "That's... not what I was talking about.\nLet's go talk over there instead.",
             "nextBlock": 7,
             "pathId": 3915819914297977087,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どうしたんですか？\r\nなんかスッゲー、上の空ですよ？",
-            "enText": "What's the matter? What's wrong with you?",
+            "enText": "So, what's wrong?\nYou seem really out of it today.",
             "nextBlock": 8,
             "pathId": -6850289028206050852,
             "blockIdx": 7
@@ -72,7 +72,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "あ、あはは。バレちゃってました？\r\nその実は……。",
-            "enText": "Oh, ha-ha. Have I been found \nout? Its actually…",
+            "enText": "Ahaha, was it that obvious?\nWell, actually...",
             "nextBlock": 9,
             "pathId": 115057179109681485,
             "blockIdx": 8
@@ -81,7 +81,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "やってみたいことがあるんです。\r\nでも私1人じゃチャレンジできないことで――",
-            "enText": "There's something I'd like to try. But it's \nsomething I can't try on my own.",
+            "enText": "There's something I want to try,\nbut I don't think I can do it alone.",
             "nextBlock": 10,
             "pathId": 6756251618372153487,
             "blockIdx": 9
@@ -90,7 +90,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……悩んでたってワケですか。\r\nふーん……。",
-            "enText": "So, you were worried about …? Hmmm…",
+            "enText": "So you've been worried\nabout something. Hm....",
             "nextBlock": 11,
             "pathId": -8377765281406071517,
             "blockIdx": 10
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "へへっ、決めた！　んじゃ、\r\nこれからの俺の時間、先輩に預けるっす！",
-            "enText": "Heh, I've decided! Then, I'll entrust you \nwith my time from now on!",
+            "enText": "Heh, alright! I've decided.\nI'm going to help you\nout with that worry.",
             "nextBlock": 12,
             "pathId": 1901640142065258812,
             "blockIdx": 11
@@ -108,7 +108,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "先輩が何をしでかそうとしてんのかは\r\n知らないっすけど！　俺、付き合うっすよ！",
-            "enText": "I don't know what you're trying to do, but… \nI'm going out with you!",
+            "enText": "I have no idea what it is that you're\ntrying to do, but I'll stick around for it!",
             "nextBlock": 13,
             "pathId": 7815187294260800176,
             "blockIdx": 12
@@ -117,7 +117,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "ええっ？　そんな悪いよ！\r\nウオッカさんも予定あるんじゃ……。",
-            "enText": "What? It's that bad! I thought \nVodka-san had plans too…",
+            "enText": "Huh? Are you really sure?\nDon't you have plans of your own?",
             "nextBlock": 14,
             "pathId": -6590027057459842654,
             "blockIdx": 13
@@ -126,7 +126,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "いいんす！　昔、父ちゃんが言ってました。\r\n何かを決める時は、自分の心の声を聞けって。",
-            "enText": "It's okay! My dad once told me. When making \na decision, listen to your heart.",
+            "enText": "It's fine, really!\nMy dad always told me to listen\nto my heart when I make decisions.",
             "nextBlock": 15,
             "pathId": -8957799080279838879,
             "blockIdx": 14
@@ -135,7 +135,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "他人にどう言われても、自分がカッケーって、\r\nワクワクする方を選ぶべき、なんだって！",
-            "enText": "No matter what other people say, you \nhave to choose the one that makes \nyou feel cool and excited!",
+            "enText": "No matter what others might say,\ndecide for yourself what you think\nwould be the cool thing to do.",
             "nextBlock": 16,
             "pathId": -1551176754044355456,
             "blockIdx": 15
@@ -144,7 +144,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "つーわけで、俺は先輩が挑戦する姿が見たい！\r\nそっちの方が、ゼッテーワクワクするんで！",
-            "enText": "That's why I want to see you challenge \nyourself! That's more exciting!",
+            "enText": "And that's why I've decided\nthat I want to witness you try.\n'Cause I'm sure it'll be something exciting!",
             "nextBlock": 17,
             "pathId": -6036979600076241784,
             "blockIdx": 16
@@ -153,7 +153,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "……！　あっ、ありがとうございます！\r\nそんなこと、言ってくれるだなんて……！",
-            "enText": "…! Oh, thank you so much! I can't \nbelieve you said that…!",
+            "enText": "T-thank you very much!\nI really appreciate you saying that.",
             "nextBlock": 18,
             "pathId": -933716041107752332,
             "blockIdx": 17
@@ -162,7 +162,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "うん……私、チャレンジするっ。\r\nウオッカさんも一緒に……お願いします！",
-            "enText": "Yeah… I'm up for the challenge. \nVodka, please join me…!",
+            "enText": "Okay... I'm going to try!\nAnd I'd be happy to have you with me!",
             "nextBlock": 19,
             "pathId": -3690960683835155002,
             "blockIdx": 18
@@ -171,7 +171,7 @@
             "jpName": "スペシャルウィーク",
             "enName": "Special Week",
             "jpText": "いざっ、『にんじんラーメン超爆盛りアブラ\r\nマシマシペアセット』に挑戦しましょーっ！！",
-            "enText": "Come on, let's try the \"Carrot Ramen Super \nBombed Up Abura Mashimashi Pair Set\"!",
+            "enText": "Let's go then, to the \"Ultra Portion\nCarrot Ramen Pair Set Challenge\"!",
             "nextBlock": 20,
             "pathId": -7819984111300581068,
             "blockIdx": 19
@@ -180,7 +180,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ええっ！？　飯の事だったんですか！？\r\nそれは流石に食いすぎじゃ……先輩ー！？",
-            "enText": "What? Did you mean the food? That's just too \nmuch food for… senpai!",
+            "enText": "Wait wha--!? You were talking about\nfood? There's no way I could eat--",
             "nextBlock": 21,
             "pathId": 6189076150026505974,
             "blockIdx": 20
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……けど、一緒にやるって言っちまったしな。\r\nダセェことはなしだ、挑戦しに行ったらぁ！",
-            "enText": "… but I said I'd do it with you. Don't be \nlame, just go for the challenge!",
+            "enText": "... no, that doesn't matter! I've decided\nthat I'd help you out, so I'll see it through!\nNot doing so would be super lame!",
             "nextBlock": 22,
             "pathId": -2101802772233131709,
             "blockIdx": 21
@@ -198,7 +198,7 @@
             "jpName": "モノローグ",
             "enName": "",
             "jpText": "そしてウオッカはスペシャルウィークと\r\n“ワクワク”をしに、中華料理屋へと\n駆け出したのだった。",
-            "enText": "Vodka then ran off to a Chinese restaurant \nto have some \"fun\" with Special Week.",
+            "enText": "And thus, Vodka ran off to a local\nChinese restaurant to have an\n\"exciting\" time with Special Week.",
             "nextBlock": -1,
             "pathId": 8211095602683301400,
             "blockIdx": 22

--- a/translations/story/83/0005/002 (夕日に誓った煌めき).json
+++ b/translations/story/83/0005/002 (夕日に誓った煌めき).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある日、河川敷に立ち寄ると――",
-            "enText": "One day, I stopped by the riverbed.",
+            "enText": "One day, as I was taking a\nwalk next to the riverbank...",
             "nextBlock": 2,
             "pathId": -8435859429240433634,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "フッ、オペラオー先輩。\r\n……先輩も、夕日を浴びに来たんすか？",
-            "enText": "Huh, Opera-o-senpai. Did… senpai also come \nto bathe in the setting sun?",
+            "enText": "Oh, Opera. Are you also\nhere to enjoy the sunset?",
             "nextBlock": 3,
             "pathId": 5447047238234037584,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "いいや、外れだ。\r\nボクはね……誓いに来たんだよ。",
-            "enText": "No, you're off. I'm here to swear an… oath.",
+            "enText": "No, that's not correct.\nI've come here to swear an oath.",
             "nextBlock": 4,
             "pathId": 6454640663030234167,
             "blockIdx": 3
@@ -36,7 +36,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……誓い？",
-            "enText": "… Vows?",
+            "enText": "... An oath?",
             "nextBlock": 5,
             "pathId": -4072338322601138936,
             "blockIdx": 4
@@ -45,7 +45,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "嗚呼、間もなく暮れてしまう太陽君にね。",
-            "enText": "Aha, the sun will soon be setting, my dear.",
+            "enText": "An oath indeed! An oath to the\nsoon to be retreating sun, you see.",
             "nextBlock": 6,
             "pathId": 4566096588024382291,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "今、彼はとても不安だろう。太陽の輝きを\r\n失ったあとの世界はどうなるのだろうかと。",
-            "enText": "She must be very worried right now. She \nwonders what the world will be like after \nthe sun loses its shine.",
+            "enText": "The sun must be very anxious right now.\nUnsure of what is to become of our world\nshould its brilliance be lost to us, that is.",
             "nextBlock": 7,
             "pathId": -1299533847842302378,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "だから安心してもらおうと思ったのさ。\r\n未来の“世紀末覇王”たるボクの誓いで、ね。",
-            "enText": "That's why I wanted to put your mind at \nease. With my vow as the future High King of \nthe End of the Century.",
+            "enText": "Thus, I have come to reassure it.\nThe oath of the one to become the\n\"End of Century Overlord\" should\nprovide ample reassurance.",
             "nextBlock": 8,
             "pathId": 203900660651334290,
             "blockIdx": 7
@@ -72,7 +72,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "さあ……太陽君。安心してゆっくりお休み。\r\nボクが君の代わりに、世界を照らし続けよう。",
-            "enText": "Come on… sunshine. Rest easy and \nrelax. I will continue to light \nup the world in your place.",
+            "enText": "Now, sun! Fret not and take your rest.\nI shall shine on the world in your absence!",
             "nextBlock": 9,
             "pathId": -3971375904663477193,
             "blockIdx": 8
@@ -81,7 +81,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "…………。",
-            "enText": "…",
+            "enText": ".........",
             "nextBlock": 10,
             "pathId": 6014395748663899748,
             "blockIdx": 9
@@ -90,7 +90,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "（はぁぁぁあっっっ！？）",
-            "enText": "（What the hell?)",
+            "enText": "(W-whaaaaa!?)",
             "nextBlock": 11,
             "pathId": 934615785527331230,
             "blockIdx": 10
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "（なんだよ覇王って！？　太陽に誓うとか\r\nありえねえだろ！　そんな、そんなの……！）",
-            "enText": "（What the hell is the High King? You can't \nswear by the sun! No, no, no, no…!)",
+            "enText": "(What is Opera even talking about?\nSwearing an oath to the sun?\nThat's just...)",
             "nextBlock": 12,
             "pathId": -779959347142392834,
             "blockIdx": 11
@@ -108,7 +108,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "（カッコよすぎんだろぉぉおっっ！？）",
-            "enText": "（It's too cool!)",
+            "enText": "(That's seriously way too damn cool...!!!)",
             "nextBlock": 13,
             "pathId": 4400063835891200755,
             "blockIdx": 12
@@ -117,7 +117,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "あ、あー……実は俺もー。\r\n太陽に誓っとくこと、あったんだったけなー？",
-            "enText": "Oh… Actually, me too. I don't know \nif I ever made a vow to the sun.",
+            "enText": "C-cough... Actually, me too.\nI also came here to do\nsomething like that, yeah.",
             "nextBlock": 14,
             "pathId": -2059376110160965150,
             "blockIdx": 13
@@ -126,7 +126,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "ほぉ。その誓いはいつか来たる無敗の王\r\nオペラオー神殿の設立よりも壮大なことかい？",
-            "enText": "Oh. Is that vow more grandiose than \nthe establishment of the Temple \nof the Undefeated King Opera-O, \nwhich will one day come?",
+            "enText": "Oho. Do you propose an oath that is\nto be even more majestic than the future founding\nof the Undefeated King Opera O's Sanctuary?",
             "nextBlock": 15,
             "pathId": -2530284535948916457,
             "blockIdx": 14
@@ -135,7 +135,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……神殿ッ！？　そ、そうっすよ！？\r\nだって、俺は……！！",
-            "enText": "… Temple! Yes, that's right! Because I'm…!",
+            "enText": "... Sanctuary!? I-I mean, yeah, I am!",
             "nextBlock": 16,
             "pathId": 454103914887193790,
             "blockIdx": 15
@@ -144,7 +144,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どんな距離でも負けないウマ娘になって！\r\nＧＩ最多記録で、みんなの度肝ぶち抜いて！",
-            "enText": "Become a horse girl who can be beaten at any \ndistance! You'll be the one to beat everyone \nwith the most GI records!",
+            "enText": "I'm going to become a horsegirl that\nwon't lose no matter the distance, after all!\nI'll rack up the highest number of G1\nwins you've ever seen, and blow\npast everyone's expectations!",
             "nextBlock": 17,
             "pathId": -5580841657482805986,
             "blockIdx": 16
@@ -153,7 +153,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "誰よりも最高の煌めきで伝説になって！\r\nばかでけぇウオッカ像とかも立てちまって！！",
-            "enText": "I want you to be a legend with the greatest \nsparkle of all time! And put up a stupidly \nlarge vodka statue!",
+            "enText": "I'll go down as a legend that shines\nlike no other, and even have them\nbuild a huge statue of myself!",
             "nextBlock": 18,
             "pathId": -4165312394445356537,
             "blockIdx": 17
@@ -162,7 +162,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "太陽の輝きに負けねぇ歴史、作るんすから！！",
-            "enText": "We're going to make history that won't lose \nto the shine of the sun!",
+            "enText": "My record will be so amazing that\nit won't even lose to the\nbrilliance of the sun!",
             "nextBlock": 19,
             "pathId": -9023838309703248599,
             "blockIdx": 18
@@ -171,7 +171,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "…………エックセッレントッッッ！！",
-            "enText": "… eckcellllllllent!",
+            "enText": "..... Excellent!!",
             "nextBlock": 20,
             "pathId": -1151371859682556524,
             "blockIdx": 19
@@ -180,7 +180,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "ウオッカ君。君の目標は気高く……クールだ！\r\nエレガントなボクにも引けを取らない！",
-            "enText": "Ms. Vodka. Your goal is to be noble and … \ncool! You're as elegant as I am!",
+            "enText": "Vodka. Your objective is a\nvery noble, a very cool one, I say!\nI dare say you are able to keep\nup with even the elegance of myself!",
             "nextBlock": 21,
             "pathId": 4800964229990100918,
             "blockIdx": 20
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……へ、へへっ♪　ま、まあ？\r\nそんな感じ？　かもしれないっすねー？",
-            "enText": "… Heh, heh… Well, well? That's \nhow I feel. I'm not sure.",
+            "enText": "... Ehehe. Yeah, y'know?\nSomething like that, kinda.",
             "nextBlock": 22,
             "pathId": -5039460990403636838,
             "blockIdx": 21
@@ -198,7 +198,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "なあ、君。まだ時間はあるかい？\r\nボクらの誓いをもっと彼に伝えに行かないか？",
-            "enText": "Hey, buddy. Do you still have time? Why \ndon't we go tell her more about our vows?",
+            "enText": "Pray, do you have time, still?\nWould you join me in further illustrating\nthe details of our oath to the sun?",
             "nextBlock": 23,
             "pathId": -72435400441732149,
             "blockIdx": 22
@@ -207,7 +207,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "…………フッ。",
-            "enText": "… foo.",
+            "enText": "... Heh.",
             "nextBlock": 24,
             "pathId": 995255952329686462,
             "blockIdx": 23
@@ -216,7 +216,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "オペラオー先輩。もちろんですっ！！",
-            "enText": "Opelao-senpai. Of course!",
+            "enText": "Of course I will, Opera!",
             "nextBlock": 25,
             "pathId": -5159313555831940820,
             "blockIdx": 24
@@ -225,7 +225,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "そして2人は走り出した。\r\n河川敷の向こう側へ、\n太陽が輝く向こう側へ――――！",
-            "enText": "And they started running. To the other side \nof the riverbed, to the other side where the \nsun shines. —!",
+            "enText": "And thus, they ran off.\nTowards the other side of riverbed,\ntowards the brilliance of the sun!",
             "nextBlock": 26,
             "pathId": -7571843958465100183,
             "blockIdx": 25
@@ -234,7 +234,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "………………。\r\nえ……なんなの？　あの2人……？",
-            "enText": "… What… are you? Those two…?",
+            "enText": "..........\nWha.... what was that about?",
             "nextBlock": 27,
             "pathId": -6682275594130650904,
             "blockIdx": 26
@@ -243,7 +243,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "せっかく自主トレしに来たのに、\r\n全っ然、集中できないんだけど……！",
-            "enText": "I've come here to train, but I \ncan't concentrate at all…!",
+            "enText": "I specifically came here to\ntrain in peace, but now I\ncan't concentrate at all...",
             "nextBlock": -1,
             "pathId": 460431919977951721,
             "blockIdx": 27

--- a/translations/story/83/0005/002 (夕日に誓った煌めき).json
+++ b/translations/story/83/0005/002 (夕日に誓った煌めき).json
@@ -63,7 +63,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "だから安心してもらおうと思ったのさ。\r\n未来の“世紀末覇王”たるボクの誓いで、ね。",
-            "enText": "Thus, I have come to reassure it.\nThe oath of the one to become the\n\"End of Century Overlord\" should\nprovide ample reassurance.",
+            "enText": "Thus, I have come to reassure it. The oath of\nthe one to become the \"End of Century\nOverlord\" should provide ample reassurance.",
             "nextBlock": 8,
             "pathId": 203900660651334290,
             "blockIdx": 7
@@ -126,7 +126,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "ほぉ。その誓いはいつか来たる無敗の王\r\nオペラオー神殿の設立よりも壮大なことかい？",
-            "enText": "Oho. Do you propose an oath that is\nto be even more majestic than the future founding\nof the Undefeated King Opera O's Sanctuary?",
+            "enText": "Oho. Do you propose an oath that is to be\neven more majestic than the future founding\nof the Undefeated King Opera O's Sanctuary?",
             "nextBlock": 15,
             "pathId": -2530284535948916457,
             "blockIdx": 14
@@ -144,7 +144,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "どんな距離でも負けないウマ娘になって！\r\nＧＩ最多記録で、みんなの度肝ぶち抜いて！",
-            "enText": "I'm going to become a horsegirl that\nwon't lose no matter the distance, after all!\nI'll rack up the highest number of G1\nwins you've ever seen, and blow\npast everyone's expectations!",
+            "enText": "I'm going to become a horsegirl that won't\nlose no matter the distance, after all! I'll\nrack up the highest number of G1 wins you've\never seen, and blow past everyone's\nexpectations!",
             "nextBlock": 17,
             "pathId": -5580841657482805986,
             "blockIdx": 16
@@ -180,7 +180,7 @@
             "jpName": "テイエムオペラオー",
             "enName": "TM Opera O",
             "jpText": "ウオッカ君。君の目標は気高く……クールだ！\r\nエレガントなボクにも引けを取らない！",
-            "enText": "Vodka. Your objective is a\nvery noble, a very cool one, I say!\nI dare say you are able to keep\nup with even the elegance of myself!",
+            "enText": "Vodka. Your objective is a very noble, a very\ncool one, I say! I dare say you are able to\nkeep up with even the elegance of myself!",
             "nextBlock": 21,
             "pathId": 4800964229990100918,
             "blockIdx": 20

--- a/translations/story/83/0005/003 (記録に残せよ？).json
+++ b/translations/story/83/0005/003 (記録に残せよ？).json
@@ -9,7 +9,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "ある日、トレーニングコースへ向かうと――",
-            "enText": "One day, I was on my way \nto the training course.",
+            "enText": "One day, as I was\nheading to the training grounds...",
             "nextBlock": 2,
             "pathId": -7054558625546394786,
             "blockIdx": 1
@@ -18,7 +18,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "――では、休憩後すぐに単独密着取材を\r\n再開するという流れでお願いしますね。",
-            "enText": "— So, I'm going to ask you to resume the \nsolo interview right after the break.",
+            "enText": "Well then, I would ask that we resume\nthe interview right after your break.",
             "nextBlock": 3,
             "pathId": -3704796847009532831,
             "blockIdx": 2
@@ -27,7 +27,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "うっす！　よろしくお願いしまーす！",
-            "enText": "Oooh! Nice to meet you!",
+            "enText": "Sounds good to me! Glad\nto be working with you!",
             "nextBlock": 4,
             "pathId": -2081964637246492403,
             "blockIdx": 3
@@ -36,7 +36,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ふぃ～、しっかしこうも\r\nずーっと見られてると疲れちまうぜ。",
-            "enText": "I'm getting tired of being watched \nlike this all the time.",
+            "enText": "Phew... man, constantly\nbeing watched sure is tiring.",
             "nextBlock": 5,
             "pathId": -8866974079986229247,
             "blockIdx": 4
@@ -45,7 +45,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……なー、スカーレット？",
-            "enText": "… Hey, Scarlett?",
+            "enText": "... right, Scarlet?",
             "nextBlock": 6,
             "pathId": -3894274883831923113,
             "blockIdx": 5
@@ -54,7 +54,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "……あらあら、随分とご機嫌じゃない。\r\nそのまま浮かれてヘマでもしそうね。",
-            "enText": "… Oh my, you're in a very good mood. I think \nI'm going to get carried away and screw up.",
+            "enText": "... You sure are in a good mood.\nWatch out you so don't slip up now.",
             "nextBlock": 7,
             "pathId": 1757797718968683259,
             "blockIdx": 6
@@ -63,7 +63,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "こんなライバルなら、別に様子を見なくても\r\n次のレースで、余裕勝ちだったわね。",
-            "enText": "With a rival like this, you could have won \nthe next race without even looking.",
+            "enText": "With a rival like you, my victory in the\nnext race feels certain even if I don't\nkeep an eye on your condition.",
             "nextBlock": 8,
             "pathId": -7421080443239380494,
             "blockIdx": 7
@@ -72,7 +72,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "はっ、お前も相変わらずだな。",
-            "enText": "Haha, you're still the same.",
+            "enText": "Hah, you sure don't change.",
             "nextBlock": 9,
             "pathId": -3413664907655788278,
             "blockIdx": 8
@@ -81,7 +81,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "ふん……ひとつだけ助言しといてあげる。\r\n下手なことを言って、後悔しないようにね？",
-            "enText": "Hmmm… I'll give you one piece of advice. I'm \nsure you'll be happy with the results.",
+            "enText": "Hmph.. let me give you one\nbit of advice. You'll regret it\nif you do anything stupid.",
             "nextBlock": 10,
             "pathId": 6503099889792985902,
             "blockIdx": 9
@@ -90,7 +90,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "取材って、記録として残るものよ。\r\n河川敷で勝手に叫ぶのとは大違いなんだから。",
-            "enText": "When you cover a story, it's a record. \nIt's very different from just shouting \non the riverbank.",
+            "enText": "You know, interviews are things\nthat leave a record.\nThey're different from casually\nshouting out claims at the riverbed.",
             "nextBlock": 11,
             "pathId": -6245780377986627874,
             "blockIdx": 10
@@ -99,7 +99,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "ははっ、ばーか。",
-            "enText": "Haha, idiot.",
+            "enText": "Hah, you don't get it at all.",
             "nextBlock": 12,
             "pathId": 6372426549394005622,
             "blockIdx": 11
@@ -108,7 +108,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "記録に残るからこそ、カッケーことを\r\n言うんだよ。俺の心に従ってな。",
-            "enText": "I'm going to say something cool for the \nrecord. Follow my heart.",
+            "enText": "Exactly because they leave a\nrecord is why you should follow your\nheart and say cool things in them!",
             "nextBlock": 13,
             "pathId": -2666321012807071746,
             "blockIdx": 12
@@ -117,7 +117,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "……ばっかみたい。",
-            "enText": "They seem to be all over…",
+            "enText": "... You're being ridiculous.",
             "nextBlock": 14,
             "pathId": -146493784328402845,
             "blockIdx": 13
@@ -126,7 +126,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "ウオッカさん。そろそろ位置に\r\nスタンバイ、お願いします。",
-            "enText": "Ms. Vodka. It's time to stand by, please.",
+            "enText": "Excuse me, it's about time for you\nto get in position. Would you please\nbe on standby, Vodka?",
             "nextBlock": 15,
             "pathId": -2341871232234778462,
             "blockIdx": 14
@@ -135,7 +135,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "おーっ！　今、行きますー！！",
-            "enText": "Ooh! I'm coming!",
+            "enText": "Yeah! I'll be right there!",
             "nextBlock": 16,
             "pathId": 2023879080725907650,
             "blockIdx": 15
@@ -144,7 +144,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……へへっ、見とけよ？",
-            "enText": "… hehe, watch this?",
+            "enText": "Heh, just watch me, okay?",
             "nextBlock": 17,
             "pathId": -5933723062555476699,
             "blockIdx": 16
@@ -153,7 +153,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "それでは、走る姿を撮影する前に――",
-            "enText": "Now, before we take pictures of you running…",
+            "enText": "Alright then. Before we move\non to the running photoshoot...",
             "nextBlock": 18,
             "pathId": -8961835011106808763,
             "blockIdx": 17
@@ -162,7 +162,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "ウオッカさん。今期最も期待される\r\nウマ娘として、ご活躍中の貴方ですが……。",
-            "enText": "Vodka-san. You are the most promising Uma \nMusume of this season…",
+            "enText": "This is considering the fact that you\nare the horsegirl on which the most\nexpectations lie recently.",
             "nextBlock": 19,
             "pathId": -4892913605567351608,
             "blockIdx": 18
@@ -171,7 +171,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "何か一言、いただけますか？",
-            "enText": "Can you give us a few words?",
+            "enText": "Are there any words or ambitions\nthat you would like to share?",
             "nextBlock": 20,
             "pathId": -8175413265364738551,
             "blockIdx": 19
@@ -180,7 +180,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "もちろん！　言うこと、決めて来たんで。",
-            "enText": "Of course! I've already decided \nwhat I'm going to say.",
+            "enText": "Of course! I've prepared what\nI want to say here in advance.",
             "nextBlock": 21,
             "pathId": 1973025293381853719,
             "blockIdx": 20
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……俺は、どんなレースでも勝つ！\r\nそしてＧＩ最多記録を塗り替えてやる！",
-            "enText": "… I'll win any race! And I'm going to break \nthe record for most GI's!",
+            "enText": "... I'm going to win any\nrace, no matter what it is!\nAnd I'll break the record\nof the most G1 wins in history too!",
             "nextBlock": 22,
             "pathId": 2608760011632540468,
             "blockIdx": 21
@@ -198,7 +198,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "俺が思う、俺が1番ワクワクすること\r\n全部やってみせるから、みんな見とけよ！",
-            "enText": "I'm going to do everything I think \nis the most exciting thing I can \ndo, so watch out for me!",
+            "enText": "I'll do what I think would be the\nmost exciting thing there is, so\nwatch me closely!",
             "nextBlock": 23,
             "pathId": -2608026402306700512,
             "blockIdx": 22
@@ -207,7 +207,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "……あのルドルフ会長の記録すら、\r\n超えるおつもりですか？",
-            "enText": "… Are you going to surpass even \nChairman Rudolph's record?",
+            "enText": "Does that mean you intend to surpass\neven the record set by the Student\nCouncil President, Rudolf?",
             "nextBlock": 24,
             "pathId": 7253163713794662767,
             "blockIdx": 23
@@ -216,7 +216,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "当然だろ。ま、でも俺の覚悟を\r\n疑いたいって言うなら――",
-            "enText": "Of course. But if you want \nto question my resolve…",
+            "enText": "Of course. But rather than\ndoubting my resolve...",
             "nextBlock": 25,
             "pathId": 7832034720486580222,
             "blockIdx": 24
@@ -225,7 +225,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "走りを見てから、言ってくれよな。",
-            "enText": "You'll tell me when you've \nseen me run, right?",
+            "enText": "Watch me run, and then talk.",
             "nextBlock": 26,
             "pathId": 5566452951397343068,
             "blockIdx": 25
@@ -234,7 +234,7 @@
             "jpName": "",
             "enName": "",
             "jpText": "そしてウオッカは走り出し――",
-            "enText": "And the vodka started running—",
+            "enText": "And thus, Vodka started running--",
             "nextBlock": 27,
             "pathId": 2341370290098909369,
             "blockIdx": 26
@@ -243,7 +243,7 @@
             "jpName": "ウマ娘A",
             "enName": "Horsegirl A",
             "jpText": "わあっ……！\r\nウオッカ、すごい……！",
-            "enText": "Wow…! Vodka, wow…!",
+            "enText": "Woah...! Vodka, you're amazing!",
             "nextBlock": 28,
             "pathId": 5049872179679735363,
             "blockIdx": 27
@@ -252,7 +252,7 @@
             "jpName": "ウマ娘B",
             "enName": "Horsegirl B",
             "jpText": "ホント！　圧倒的な走りっていうか、\r\nレースも楽しみだね！",
-            "enText": "That's right! I'm looking \nforward to the race!",
+            "enText": "You're right! I'm really looking forward\nto seeing that overwhelming\nrunning in the actual race!",
             "nextBlock": 29,
             "pathId": 1125278116237649176,
             "blockIdx": 28
@@ -261,7 +261,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "……素晴らしい子ね。彼女なら、\r\n先ほどの言葉も将来実現して……！",
-            "enText": "… She's a wonderful girl. She'll make what \nyou just said come true in the future…!",
+            "enText": "... She truly is incredible. Seeing\nher like this really makes me feel\nthe weight behind her words.",
             "nextBlock": 30,
             "pathId": 8466171520831954349,
             "blockIdx": 29
@@ -270,7 +270,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "ふふっ……密着取材の許可をいただけて、\r\n本っ当によかったわぁ……！　すぐ編集長に\n連絡して、来月号の特集を……！！",
-            "enText": "I'm so glad I got permission to do the … \ninterview…! I'm going to contact my editor \nright away and get a feature on… for next \nmonth's issue!",
+            "enText": "Hah... I'm so glad I got permission\nto interview her! I need to get in touch\nwith the editor-in-chief asap!\nI really want to get her\nfeatured in next month's issue...!",
             "nextBlock": 31,
             "pathId": -5622085605181465228,
             "blockIdx": 30
@@ -279,7 +279,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "…………ふんっ。",
-            "enText": "… Hmmm.",
+            "enText": ".... Hmph!",
             "nextBlock": 32,
             "pathId": 2634955152653482335,
             "blockIdx": 31
@@ -288,7 +288,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "……調子はいいみたいだけど。\r\n次のレースは絶対、アタシが勝つんだから！",
-            "enText": "… You seem to be in good shape. The next \nrace, I'm going to win!",
+            "enText": "... She might look like she's in\ngood form, but the one who'll win\nthe next race is going to be me!",
             "nextBlock": -1,
             "pathId": -3186721197719466328,
             "blockIdx": 32

--- a/translations/story/83/0005/003 (記録に残せよ？).json
+++ b/translations/story/83/0005/003 (記録に残せよ？).json
@@ -90,7 +90,7 @@
             "jpName": "ダイワスカーレット",
             "enName": "Daiwa Scarlet",
             "jpText": "取材って、記録として残るものよ。\r\n河川敷で勝手に叫ぶのとは大違いなんだから。",
-            "enText": "You know, interviews are things\nthat leave a record.\nThey're different from casually\nshouting out claims at the riverbed.",
+            "enText": "You know, interviews are things that leave a\nrecord. They're different from casually\nshouting out claims at the riverbed.",
             "nextBlock": 11,
             "pathId": -6245780377986627874,
             "blockIdx": 10
@@ -189,7 +189,7 @@
             "jpName": "ウオッカ",
             "enName": "Vodka",
             "jpText": "……俺は、どんなレースでも勝つ！\r\nそしてＧＩ最多記録を塗り替えてやる！",
-            "enText": "... I'm going to win any\nrace, no matter what it is!\nAnd I'll break the record\nof the most G1 wins in history too!",
+            "enText": "... I'm going to win any race, no matter what\nit is! And I'll break the record of the most\nG1 wins in history too!",
             "nextBlock": 22,
             "pathId": 2608760011632540468,
             "blockIdx": 21
@@ -270,7 +270,7 @@
             "jpName": "乙名史記者",
             "enName": "Otonashi Etsuko",
             "jpText": "ふふっ……密着取材の許可をいただけて、\r\n本っ当によかったわぁ……！　すぐ編集長に\n連絡して、来月号の特集を……！！",
-            "enText": "Hah... I'm so glad I got permission\nto interview her! I need to get in touch\nwith the editor-in-chief asap!\nI really want to get her\nfeatured in next month's issue...!",
+            "enText": "Hah... I'm so glad I got permission to\ninterview her! I need to get in touch with\nthe editor-in-chief asap! I really want to\nget her featured in next month's issue...!",
             "nextBlock": 31,
             "pathId": -5622085605181465228,
             "blockIdx": 30


### PR DESCRIPTION
This PR adds proper translation for the training events of the "Road of Vodka" (SSR) Vodka support card.

Textprocessing was run with the ``-rep none`` argument, linebreaks have otherwise retained where suitable. I've also reprocessed the R and SR events with these parameters.