### PR TITLE
Adjusting duration on all lines

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -132,7 +132,7 @@ def patchVersion():
 
 class NewArgs(argparse.ArgumentParser):
     def __init__(self, desc) -> None:
-        if sys.argv[1] in ("-v", "--version"):
+        if len(sys.argv) > 1 and sys.argv[1] in ("-v", "--version"):
             print(f"Patch version: {patchVersion()}")
             sys.exit()
         super().__init__(description=desc, conflict_handler='resolve')

--- a/src/extract.py
+++ b/src/extract.py
@@ -282,6 +282,8 @@ class DataTransfer():
                     cText['enText'] = targetBlock['coloredText'][txtIdx]['enText']
             if 'skip' in targetBlock:
                 textData['skip'] = targetBlock['skip']
+            if 'newClipLength' in targetBlock:
+                textData['newClipLength'] = targetBlock['newClipLength']
 
 
 def exportData(data, filepath: str):

--- a/src/extract.py
+++ b/src/extract.py
@@ -133,8 +133,7 @@ def extractAsset(path, storyId, tlFile = None):
                         print(f"Attempting anim data export at BlockIndex {block['BlockIndex']}")
                         clipsToUpdate = list()
                         for trackGroup in block['CharacterTrackList']:
-                            keys = trackGroup.keys()
-                            for key in keys:
+                            for key in trackGroup.keys():
                                 if key.endswith("MotionTrackData") and trackGroup[key]['ClipList']:
                                     clipsToUpdate.append(trackGroup[key]['ClipList'][-1]['m_PathID'])
                         if clipsToUpdate:
@@ -148,7 +147,7 @@ def extractAsset(path, storyId, tlFile = None):
                                     animGroupData['pathId'] = clipPathId
                                     textData['animData'].append(animGroupData)
                                 else:
-                                    print(f"No anim asset ({clipPathId}) found at BlockIndex {block['BlockIndex']}")
+                                    print(f"Couldn't find anim asset ({clipPathId}) at BlockIndex {block['BlockIndex']}")
                         else:
                             print(f"Anim clip list empty at BlockIndex {block['BlockIndex']}")
 

--- a/src/extract.py
+++ b/src/extract.py
@@ -130,7 +130,7 @@ def extractAsset(path, storyId, tlFile = None):
                         continue
                     if isPatched(textData): return
 
-                    if "origTxtLen" in textData: # added for unvoiced clips
+                    if "origClipLength" in textData:
                         print(f"Attempting anim data export at BlockIndex {block['BlockIndex']}")
                         animClips = block['CharacterTrackList'][0]['StoryTimelineCharaMotionTrackData']['ClipList']
                         animClips = [(i, t['StoryTimelineCharaMotionTrackData']['ClipList']) for i, t in enumerate(block['CharacterTrackList'])]
@@ -191,10 +191,9 @@ def extractText(assetType, obj):
             'enName': "",  # todo: auto lookup
             'jpText': tree['Text'],
             'enText': "",
-            'nextBlock': tree['NextBlock'] # maybe for adding blocks to split dialogue later
+            'nextBlock': tree['NextBlock'], # maybe for adding blocks to split dialogue later
+            'origClipLength': tree['ClipLength']
         }
-        if tree['VoiceLength'] == -1:
-            o['origTxtLen'] = tree['ClipLength']
         choices = tree['ChoiceDataList'] #always present
         if choices:
             o['choices'] = list()

--- a/src/import.py
+++ b/src/import.py
@@ -168,6 +168,12 @@ class StoryPatcher:
                 if "origClipLength" in textBlock and textBlock['enText']:
                     print(f"Adjusting text length at {blockIdx}")
                     newClipLen = int(assetData['WaitFrame'] + len(textBlock['enText']) / self.manager.args.cps * self.manager.args.fps)
+                    if "newClipLength" in textBlock and textBlock["newClipLength"]:
+                        try:
+                            newClipLen = int(textBlock["newClipLength"])
+                        except ValueError:
+                            print(f"{self.manager.tlFile.bundle}: {blockIdx}: Invalid clip length, skipping.")
+                            continue
                     newClipLen = max(textBlock['origClipLength'], newClipLen)
                     newBlockLen = newClipLen + assetData['StartFrame'] + 1
                     assetData['ClipLength'] = newClipLen

--- a/src/import.py
+++ b/src/import.py
@@ -38,12 +38,8 @@ class PatchManager:
                 self.errorLog = stdout
 
     def start(self):
-        if self.args.src:
-            print(f"Importing {self.args.src} to {self.args.dst}")
-            files = [self.args.src]
-        else:
-            print(f"Importing group {self.args.group or 'all'}, id {self.args.id or 'all'}, idx {self.args.idx or 'all'} from translations\{self.args.type} to {self.args.dst}")
-            files = common.searchFiles(self.args.type, self.args.group, self.args.id, self.args.idx)
+        print(f"Importing group {self.args.group or 'all'}, id {self.args.id or 'all'}, idx {self.args.idx or 'all'} from translations\{self.args.type} to {self.args.dst}")
+        files = common.searchFiles(self.args.type, self.args.group, self.args.id, self.args.idx)
         nFiles = len(files)
         nErrors = 0
         print(f"Found {nFiles} files.")

--- a/src/import.py
+++ b/src/import.py
@@ -166,7 +166,6 @@ class StoryPatcher:
                 # cliplength = max(0, voicelength OR (text-length * cps / fps)) + waitframe
                 # waitframe: usually 12 if voiced, 45 otherwise BUT random exceptions occur
                 if "origClipLength" in textBlock and textBlock['enText']:
-                    print(f"Adjusting text length at {blockIdx}")
                     newTxtLen = len(textBlock['enText']) / self.manager.args.cps * self.manager.args.fps
                     newClipLen = int(assetData['WaitFrame'] + max(newTxtLen, assetData['VoiceLength']))
                     if "newClipLength" in textBlock and textBlock["newClipLength"]:
@@ -178,17 +177,19 @@ class StoryPatcher:
                     newBlockLen = max(textBlock['origClipLength'], newClipLen) + assetData['StartFrame'] + 1
                     assetData['ClipLength'] = newClipLen
                     mainTree['BlockList'][blockIdx]['BlockLength'] = newBlockLen
+                    if not self.manager.args.silent and newClipLen > textBlock['origClipLength']:
+                        print(f"Adjusted TextClip length at {blockIdx}: {textBlock['origClipLength']} -> {newClipLen}")
 
                     if "animData" in textBlock:
-                        print(f"Adjusting anim length at {blockIdx}")
                         for animGroup in textBlock['animData']:
                             animAsset = self.manager.assets[animGroup['pathId']]
                             if animAsset:
                                 animData = animAsset.read_typetree()
                                 animData['ClipLength'] = animGroup['origLen'] + newClipLen - textBlock['origClipLength']
                                 animAsset.save_typetree(animData)
-                                print(f"Adjusted anim length from {animGroup['origLen']} to {animData['ClipLength']}")
-                            else: print(f"Can't find animation pathId ({animGroup['pathId']}) at {blockIdx}")
+                                if not self.manager.args.silent:
+                                    print(f"Adjusted AnimClip length at {blockIdx}: {animGroup['origLen']} -> {animData['ClipLength']}")
+                            elif not self.manager.args.silent: print(f"Can't find animation asset ({animGroup['pathId']}) at {blockIdx}")
                     else:
                         print(f"Text length adjusted but no anim data found at {blockIdx}")
 

--- a/src/import.py
+++ b/src/import.py
@@ -171,7 +171,12 @@ class StoryPatcher:
                     newClipLen = max(textBlock['origClipLength'], newClipLen)
                     newBlockLen = newClipLen + assetData['StartFrame'] + 1
                     assetData['ClipLength'] = newClipLen
+
+                    if assetData['VoiceLength'] != -1:
+                        assetData['VoiceLength'] = assetData['ClipLength'] - assetData['WaitFrame']
+
                     mainTree['BlockList'][blockIdx]['BlockLength'] = newBlockLen
+
                     if "animData" in textBlock:
                         print(f"Adjusting anim length at {blockIdx}")
                         for animGroup in textBlock['animData']:

--- a/src/import.py
+++ b/src/import.py
@@ -167,20 +167,16 @@ class StoryPatcher:
                 # waitframe: usually 12 if voiced, 45 otherwise BUT random exceptions occur
                 if "origClipLength" in textBlock and textBlock['enText']:
                     print(f"Adjusting text length at {blockIdx}")
-                    newClipLen = int(assetData['WaitFrame'] + len(textBlock['enText']) / self.manager.args.cps * self.manager.args.fps)
+                    newTxtLen = len(textBlock['enText']) / self.manager.args.cps * self.manager.args.fps
+                    newClipLen = int(assetData['WaitFrame'] + max(newTxtLen, assetData['VoiceLength']))
                     if "newClipLength" in textBlock and textBlock["newClipLength"]:
                         try:
                             newClipLen = int(textBlock["newClipLength"])
                         except ValueError:
                             print(f"{self.manager.tlFile.bundle}: {blockIdx}: Invalid clip length, skipping.")
                             continue
-                    newClipLen = max(textBlock['origClipLength'], newClipLen)
-                    newBlockLen = newClipLen + assetData['StartFrame'] + 1
+                    newBlockLen = max(textBlock['origClipLength'], newClipLen) + assetData['StartFrame'] + 1
                     assetData['ClipLength'] = newClipLen
-
-                    if assetData['VoiceLength'] != -1:
-                        assetData['VoiceLength'] = assetData['ClipLength'] - assetData['WaitFrame']
-
                     mainTree['BlockList'][blockIdx]['BlockLength'] = newBlockLen
 
                     if "animData" in textBlock:


### PR DESCRIPTION
Added functionality to automatically adjust all text blocks' durations on import.
- Backwards compatible with old export.py jsons; will skip adjusting durations with older files.
- Also automatically increases duration of final animations of the text block. (Should™ ensure animations extend until the new clip length. I did not test this very thoroughly so there could be exceptions where the animations still break.)
- Adding "newClipLength" to a story text block's data allows you to set a custom clip length instead of the automatic calculation.

Also fixed a small bug in common.py which caused import.py to crash if it was executed without any arguments.