### PR TITLE
Use DMM config to find install dir

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,10 +1,12 @@
-from typing import Union
+from typing import Union, Optional
 import regex
 import json
 from pathlib import Path
+import os
 from os import PathLike
 import winreg
 
+DMM_CONFIG = Path(os.environ['APPDATA']) / "dmmgameplayer5" / "dmmgame.cnf"
 
 def readJson(file: PathLike) -> Union[dict, list]:
     with open(file, "r", encoding="utf8") as f:
@@ -43,9 +45,18 @@ def isJapanese(text):
 def isEnglish(text):
     return regex.fullmatch(r"[^\p{Katakana}\p{Hiragana}\p{Han}\p{InHalfwidth_and_Fullwidth_Forms}。]+", text)
 
-def getUmaInstallPath():
+def getUmaInstallDir() -> Optional[Path]:
+    """Return the path to the directory umamusume.exe was installed in, or None if it can't be found."""
+    if DMM_CONFIG.is_file():
+        with open(DMM_CONFIG, encoding='utf-8') as f:
+            dmm_um_config = next((game for game in json.load(f)['contents'] if game['productId'] == "umamusume"), None)
+            if dmm_um_config is not None:
+                return Path(dmm_um_config['detail']['path'])
+
+    # Older DMM installations might not have the DMM config file, if it wasn't found try an old registry check approach
     try:
-        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6432Node\DMM GAMES\Launcher\Content\umamusume") as k:
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                            r"SOFTWARE\WOW6432Node\DMM GAMES\Launcher\Content\umamusume") as k:
             return Path(winreg.QueryValueEx(k, "Path")[0])
     except:
         return None

--- a/src/manage.py
+++ b/src/manage.py
@@ -137,7 +137,7 @@ def parseArgs():
     args = ap.parse_args()
 
     if args.src is None or (args.import_only and args.src == LOCAL_DUMP):
-        path = helpers.getUmaInstallPath()
+        path = helpers.getUmaInstallDir()
         if path: path = path.joinpath("dump.txt")
         else: print("Couldn't find game path.")
         if path.exists():
@@ -179,7 +179,7 @@ def main():
         helpers.writeJson(HASH_FILE_DYNAMIC, hashData[1])
 
     if args.move:
-        path = helpers.getUmaInstallPath()
+        path = helpers.getUmaInstallDir()
         if path:
             shutil.copyfile(HASH_FILE_STATIC, path.joinpath(HASH_FILE_STATIC.relative_to(HASH_FILE_STATIC.parents[1])))
             shutil.copyfile(HASH_FILE_DYNAMIC, path.joinpath(HASH_FILE_DYNAMIC.relative_to(HASH_FILE_DYNAMIC.parents[1])))


### PR DESCRIPTION
* Fixes install dir not being found for current DMM installations,
  falling back to the old reg key check if DMM config isn't found.