### PR TITLE
Silence run.bat for expected non-import cases

### DIFF
--- a/src/filecopy.py
+++ b/src/filecopy.py
@@ -74,7 +74,8 @@ def copy(hash, args):
     asset = common.GameBundle.fromName(hash, load=False)
     dst = path.join(args.dst, hash)
     if not asset.exists:
-        print(f"Couldn't find {asset.bundlePath}, skipping...")
+        if args.verbose:
+            print(f"Couldn't find {asset.bundlePath}, skipping...")
         return 0
     elif args.overwrite or not path.exists(dst):
         asset.readPatchState()
@@ -88,7 +89,8 @@ def copy(hash, args):
                 print(f"Unknown error: {repr(e)}, skipping...")
                 return 0
     else:
-        print(f"Skipping existing: {asset.bundleName}")
+        if args.verbose:
+            print(f"Skipping existing: {asset.bundleName}")
         return 0
 
 

--- a/src/import.py
+++ b/src/import.py
@@ -45,20 +45,20 @@ class PatchManager:
         print(f"Found {nFiles} files.")
 
         for file in files:
-            print(f"Importing {file}... ", end="", flush=True)
             try:
                 if self.patch(file):
-                    print("done.")
+                    print(f"Imported {file}")
                 else:
                     nFiles -= 1
-                    print("not modified.")
+            except (NoAssetError, AlreadyPatchedError):
+                nFiles -= 1  # Expected behaviour; don't print
             except PatchError as e:
                 nFiles -= 1
-                print(f"skipped: {e}")
+                print(f"Skipped {file}: {e}")
             except:
                 nFiles -= 1
                 nErrors += 1
-                print("error.") # newline
+                print(f"Error importing {file}")
                 if self.args.silent:
                     print(f"Error in {file}", file=self.errorLog)
                     print_exc(chain=True, file=self.errorLog)


### PR DESCRIPTION
run.bat is a bit faster and now helpfully shows
only what it actually changed.