### PR TITLE
Simplifying refactors

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -28,15 +28,6 @@ def _to_json(o):
         raise TypeError
 
 
-def findExisting(searchPath: PathLike, filePattern: str):
-    searchPath = Path(searchPath)
-    search = searchPath.glob(filePattern)
-    for file in search:
-        if file.is_file():
-            return file
-    return None
-
-
 def isParseableInt(x):
     try:
         int(x)

--- a/src/snep-import.py
+++ b/src/snep-import.py
@@ -6,10 +6,10 @@ from os import system as run
 snep = Path("translations/snep").glob("story_*")
 
 for file in snep:
-    g, id, idx = common.parseStoryId("story", file.stem, True)
+    g, id, idx = common.parseStoryIdFromPath("story", file.stem)
 
     extract = common.searchFiles("story", g, id, idx)
-    if not extract: 
+    if not extract:
         print("Can't find own file")
         raise SystemExit
     extract = common.TranslationFile(extract[0])
@@ -18,7 +18,7 @@ for file in snep:
     if not sneptl:
         print("Can't find snep text")
         raise SystemExit
-        
+
     for k, v in sneptl.items():
         if k.startswith("*"): continue
         try:
@@ -27,7 +27,7 @@ for file in snep:
         except:
             idx, dunno, type = k.split(".")
         idx = int(idx) - 1
-        
+
         ourblock = extract.textBlocks[idx]
         if type == "text":
             ourblock["enText"] = v
@@ -37,4 +37,3 @@ for file in snep:
                 raise SystemExit
             ourblock["choices"][subidx]["enText"]= v
     extract.save()
-

--- a/src/textprocess.py
+++ b/src/textprocess.py
@@ -187,7 +187,7 @@ def calcLineLen(file: TranslationFile, verbose):
     if lineLength is None:
         if (file.type in ("lyrics", "race")
             or (file.type == "story"
-                and common.parseStoryId(file.type, file.getStoryId(), fromPath=False)[0] in ("02", "04", "09"))):
+                and common.parseStoryId(file.type, file.getStoryId())[0] in ("02", "04", "09"))):
             lineLength = 65
         else:
             lineLength = 45


### PR DESCRIPTION
* Remove findExisting as all callers had Path values to call one-liner
  globs with anyway.
* Split parseStoryId into two functions as its behaviour was completely
  dependent on a boolean flag.
* Simplify manage.py `clean` and make it default to `both` (or accept `ui` or `dump`)
* Also make extract.py only mention skipped files in verbose mode, as
  eventually almost all files will already be extracted.
* Reduce indentation levels on large functions
* minor style cleanups