### PR TITLE
Auto MTL fixes

### DIFF
--- a/src/deepl-translator.user.js
+++ b/src/deepl-translator.user.js
@@ -13,8 +13,8 @@
 'use strict'
 
 class Translator {
-    input = document.querySelector("textarea.lmt__source_textarea")
-    output = document.querySelector("textarea.lmt__target_textarea")
+    input = document.querySelector(".lmt__source_textarea")
+    output = document.querySelector(".lmt__target_textarea")
     obs = new MutationObserver(this.rcvText.bind(this))
     clearText = false // DeepL seems to be affected by previous text sometimes. This might good for sequential text like stories (?), perhaps not for random text. Idk
     timeout = 3000
@@ -24,7 +24,11 @@ class Translator {
         this.obs.observe(document.querySelector("#target-dummydiv"), { childList: true })
         if (clear) this.clearText = clear
     }
-    sendText(txt) {
+    async sendText(txt) {
+        while (this.tl || this.output.value) {
+            await new Promise(r => setTimeout(r, 500));
+        }
+
         this.tl = true
         this.input.value = txt
         this.input.dispatchEvent(new InputEvent("input"))

--- a/src/textprocess.py
+++ b/src/textprocess.py
@@ -16,7 +16,7 @@ def processText(file: TranslationFile, text: str, opts: dict):
         text = cleannewLines(text)
     if opts.get("replaceMode"):
         text = replace(text, opts["replaceMode"])
-    if opts.get("lineLength") != 0:
+    if opts.get("lineLength") != None and opts.get("lineLength") != 0:
         text = adjustLength(file, text, opts)
 
     text = resizeText(file, text, force = opts.get("forceResize"))


### PR DESCRIPTION
The browser script that integrates with DeepL was fixed, and duplicate text in the MTL process should be now no longer be a problem.

The browser script now also waits for the translated output to be fully retrieved. I noticed that, at least when translating lobby lines, many would get translated with previous lines.
Honestly not sure if my solution is satisfactory, would appreciate feedback if there's a better alternative.