### PR TITLE
Fix length of screen effect clips if they originally extended until the end of the block.

### DIFF
--- a/src/import.py
+++ b/src/import.py
@@ -260,6 +260,32 @@ class StoryPatcher:
                                             )
                         elif self.manager.args.verbose:
                             print(f"Text length adjusted but no anim data found at {blockIdx}")
+                        
+                        # Adjust length of screen effect clips if they originally extended until the end of the block.
+                        for track in self.assetData["BlockList"][blockIdx]['ScreenEffectTrackList']:
+                            if not track['ClipList']:
+                                continue
+                            clipPathID = track['ClipList'][-1]['m_PathID']
+                            try:
+                                clipAsset = self.bundle.assets[clipPathID]
+                            except KeyError:
+                                if self.manager.args.verbose:
+                                    print(
+                                        f"Can't find screen effect clip asset ({clipPathID}) at {blockIdx}"
+                                    )
+                            else:
+                                clipData = clipAsset.read_typetree()
+                                
+                                if clipData['StartFrame'] + clipData['ClipLength'] < assetData["StartFrame"] + textBlock["origClipLength"]:
+                                    continue
+
+                                tmpClipLen = clipData['ClipLength']
+                                clipData["ClipLength"] = tmpClipLen + newClipLen - textBlock["origClipLength"]
+                                clipAsset.save_typetree(clipData)
+                                if self.manager.args.verbose:
+                                    print(
+                                        f"Adjusted ScreenEffectClip length at {blockIdx}: {tmpClipLen} -> {clipData['ClipLength']}"
+                                    )
 
                 if "choices" in textBlock:
                     jpChoices, enChoices = assetData["ChoiceDataList"], textBlock["choices"]


### PR DESCRIPTION
I stumbled upon the issue where screen effects abruptly cut off if the new text blocks extend longer than the original ones, and it seems to be rather common.
Since I'm reimplementing story imports elsewhere, I thought I might as well add the fix here too, as courtesy since I originally wrote the anim length extension code for UmaTL which has this flaw.